### PR TITLE
updating the nuget package configs to point to the new package name

### DIFF
--- a/e2etest/test/Microsoft.WindowsAzure.Mobile.Net45.Test/packages.config
+++ b/e2etest/test/Microsoft.WindowsAzure.Mobile.Net45.Test/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="WindowsAzure.MobileServices" version="2.0.0-beta-2" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.0-rc" targetFramework="net45" />
 </packages>

--- a/e2etest/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/packages.config
+++ b/e2etest/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="WindowsAzure.MobileServices" version="2.0.0-beta" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.0-rc" targetFramework="net45" />
 </packages>

--- a/e2etest/test/Microsoft.WindowsAzure.MobileServices.Android.Test/packages.config
+++ b/e2etest/test/Microsoft.WindowsAzure.MobileServices.Android.Test/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="MonoAndroid23" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="MonoAndroid23" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="MonoAndroid23" />
-  <package id="WindowsAzure.MobileServices" version="2.0.0-beta" targetFramework="MonoAndroid23" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.0-rc" targetFramework="MonoAndroid23" />
 </packages>

--- a/e2etest/test/Microsoft.WindowsAzure.MobileServices.Test/packages.config
+++ b/e2etest/test/Microsoft.WindowsAzure.MobileServices.Test/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="WindowsAzure.MobileServices" version="2.0.0-beta-2" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.0-rc" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
 </packages>

--- a/e2etest/test/Microsoft.WindowsAzure.MobileServices.TestFramework/packages.config
+++ b/e2etest/test/Microsoft.WindowsAzure.MobileServices.TestFramework/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="WindowsAzure.MobileServices" version="2.0.0-beta-2" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.0-rc" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
 </packages>

--- a/e2etest/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.Test/packages.config
+++ b/e2etest/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.Test/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="wp81" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="wp81" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="wp81" />
-  <package id="WindowsAzure.MobileServices" version="2.0.0-beta-2" targetFramework="wp81" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.0-rc" targetFramework="wp81" />
 </packages>

--- a/e2etest/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone81.Test/packages.config
+++ b/e2etest/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone81.Test/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="wpa81" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="wpa81" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="wpa81" />
-  <package id="WindowsAzure.MobileServices" version="2.0.0-beta-2" targetFramework="wpa81" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.0-rc" targetFramework="wpa81" />
 </packages>

--- a/e2etest/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/packages.config
+++ b/e2etest/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/packages.config
@@ -6,6 +6,6 @@
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="win81" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="win81" />
   <package id="SQLitePCL" version="3.8.7.2" targetFramework="win81" />
-  <package id="WindowsAzure.MobileServices" version="2.0.0-beta-2" targetFramework="win81" />
-  <package id="WindowsAzure.MobileServices.SQLiteStore" version="2.0.0-beta" targetFramework="win81" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.0-rc" targetFramework="win81" />
+  <package id="Microsoft.Azure.Mobile.Client.SQLiteStore" version="2.0.0-rc" targetFramework="win81" />
 </packages>

--- a/e2etest/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/packages.config
+++ b/e2etest/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="xamarinios10" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="xamarinios10" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="xamarinios10" />
-  <package id="WindowsAzure.MobileServices" version="2.0.0-beta" targetFramework="xamarinios10" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.0-rc" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
The target framework strings of "portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" break installing the packages in the .Test and .TestFramework using VS2013. VS2015 does its own thing and installs them just fine... will probably update these strings as well