### PR TITLE
Convert JObject to string for xamarin ios and andriod template parameter's body

### DIFF
--- a/sdk/src/Microsoft.WindowsAzure.MobileServices.Android/Push/Push.cs
+++ b/sdk/src/Microsoft.WindowsAzure.MobileServices.Android/Push/Push.cs
@@ -75,7 +75,17 @@ namespace Microsoft.WindowsAzure.MobileServices
             installation[PushInstallationProperties.PLATFORM] = Platform.Instance.PushUtility.GetPlatform();
             if (templates != null)
             {
-                installation[PushInstallationProperties.TEMPLATES] = templates;
+                JObject templatesWithStringBody = templates;
+                foreach (JProperty template in templates.Properties())
+                {
+                    //Notification hub requires template body to be a string.Convert to string from JObject
+                    var templateBody = template.Value["body"];
+                    if (templateBody != null && templateBody.GetType() == typeof(JObject))
+                    {
+                        templatesWithStringBody[template.Name]["body"] = templateBody.ToString();
+                    }
+                }
+                installation[PushInstallationProperties.TEMPLATES] = templatesWithStringBody;
             }
             return this.PushHttpClient.CreateOrUpdateInstallationAsync(installation);
         }

--- a/sdk/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/Push.cs
+++ b/sdk/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/Push.cs
@@ -77,7 +77,17 @@ namespace Microsoft.WindowsAzure.MobileServices
             installation[PushInstallationProperties.PLATFORM] = Platform.Instance.PushUtility.GetPlatform();
             if (templates != null)
             {
-                installation[PushInstallationProperties.TEMPLATES] = templates;
+                JObject templatesWithStringBody = templates;
+                foreach (JProperty template in templates.Properties())
+                {
+                    //Notification hub requires template body to be a string.Convert to string from JObject
+                    var templateBody = template.Value["body"];
+                    if (templateBody != null && templateBody.GetType() == typeof(JObject))
+                    {
+                        templatesWithStringBody[template.Name]["body"] = templateBody.ToString();
+                    }
+                }
+                installation[PushInstallationProperties.TEMPLATES] = templatesWithStringBody;
             }
             return this.PushHttpClient.CreateOrUpdateInstallationAsync(installation);
         }

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/Microsoft.WindowsAzure.Mobile.Android.Test.csproj
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/Microsoft.WindowsAzure.Mobile.Android.Test.csproj
@@ -19,14 +19,24 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidLinkMode>Full</AndroidLinkMode>
+    <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
+    <AndroidLinkSkip />
+    <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
+    <BundleAssemblies>False</BundleAssemblies>
+    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+    <AndroidSupportedAbis />
+    <AndroidStoreUncompressedFileExtensions />
+    <MandroidI18n />
+    <Debugger>Xamarin</Debugger>
+    <AndroidEnableMultiDex>False</AndroidEnableMultiDex>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/Properties/AssemblyInfo.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Android.App;
+using Microsoft.WindowsAzure.MobileServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -15,6 +16,7 @@ using Android.App;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
+[assembly: Preserve]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/TestPlatform/PushTestUtility.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/TestPlatform/PushTestUtility.cs
@@ -13,7 +13,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
     class PushTestUtility : IPushTestUtility
     {
         private const string DefaultChannelUri = "17BA0791499DB908433B80F37C5FBC89B870084B";
-
+        const string DefaultToastTemplateName = "templateForToastGcm";
         public string GetPushHandle()
         {
             return DefaultChannelUri;
@@ -24,29 +24,33 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             return DefaultChannelUri.Replace('A', 'B');
         }
 
-        public JObject GetInstallation(string installationId, bool includeTemplates = false, string defaultChannelUri = null)
+        public JObject GetInstallation(string installationId, bool includeTemplates = false, bool templateBodyJson = false, string defaultChannelUri = null)
         {
             JObject installation = new JObject();
             installation[PushInstallationProperties.PUSHCHANNEL] = defaultChannelUri ?? DefaultChannelUri;
             installation[PushInstallationProperties.PLATFORM] = Platform.Instance.PushUtility.GetPlatform();
             if (includeTemplates)
             {
-                JObject msg = new JObject();
-                msg["msg"] = "$(message)";
-                JObject data = new JObject();
-                data["data"] = msg;
-                installation[PushInstallationProperties.TEMPLATES] = data;
+                installation[PushInstallationProperties.TEMPLATES] = GetTemplates(templateBodyJson);
             }
             return installation;
         }
 
-        public JObject GetTemplates()
+        public JObject GetTemplates(bool templateBodyJson = false)
         {
             JObject msg = new JObject();
             msg["msg"] = "$(message)";
             JObject data = new JObject();
             data["data"] = msg;
-            return data;
+            JObject templateBody = new JObject();
+            templateBody["body"] = data.ToString();
+            if (templateBodyJson)
+            {
+                templateBody["body"] = data;
+            }
+            JObject templates = new JObject();
+            templates[DefaultToastTemplateName] = templateBody;
+            return templates;
         }
     }
 }

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/UnitTests/PushUnit.Test.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/UnitTests/PushUnit.Test.cs
@@ -48,7 +48,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             var mobileClient = new MobileServiceClient(DefaultServiceUri);
             string emptyRegistrationId = string.Empty;
             var exception = await AssertEx.Throws<ArgumentNullException>(() => mobileClient.GetPush().RegisterAsync(emptyRegistrationId));
-            Assert.AreEqual(exception.Message, "Argument cannot be null.\nParameter name: registrationId");
+            Assert.AreEqual(exception.Message, "Value cannot be null.\nParameter name: registrationId");
         }
 
         [AsyncTestMethod]
@@ -63,7 +63,21 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
         }
 
         [AsyncTestMethod]
-        public async Task RegisterAsync_WithTemplates()
+        public async Task RegisterAsync_WithTemplates_TemplateBodyJson()
+        {
+            MobileServiceClient mobileClient = new MobileServiceClient(DefaultServiceUri);
+
+            var expectedUri = string.Format("{0}{1}/{2}", DefaultServiceUri, InstallationsPath, mobileClient.GetPush().InstallationId);
+            JObject templates = this.pushTestUtility.GetTemplates(true);
+            string installationRegistration = JsonConvert.SerializeObject(this.pushTestUtility.GetInstallation(mobileClient.GetPush().InstallationId, true));
+            var hijack = TestHttpDelegatingHandler.CreateTestHttpHandler(expectedUri, HttpMethod.Put, null, HttpStatusCode.OK, expectedRequestContent: installationRegistration);
+
+            mobileClient = new MobileServiceClient(DefaultServiceUri, hijack);
+            await mobileClient.GetPush().RegisterAsync(this.registrationId, templates);
+        }
+
+        [AsyncTestMethod]
+        public async Task RegisterAsync_WithTemplates_TemplateBodyString()
         {
             MobileServiceClient mobileClient = new MobileServiceClient(DefaultServiceUri);
 

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/UnitTests/PushUnit.Test.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.Android.Test/UnitTests/PushUnit.Test.cs
@@ -48,7 +48,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             var mobileClient = new MobileServiceClient(DefaultServiceUri);
             string emptyRegistrationId = string.Empty;
             var exception = await AssertEx.Throws<ArgumentNullException>(() => mobileClient.GetPush().RegisterAsync(emptyRegistrationId));
-            Assert.AreEqual(exception.Message, "Value cannot be null.\nParameter name: registrationId");
+            Assert.AreEqual(exception.ParamName, "registrationId");
         }
 
         [AsyncTestMethod]

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.Test/TestPlatform/IPushTestUtility.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.Test/TestPlatform/IPushTestUtility.cs
@@ -15,10 +15,10 @@ namespace Microsoft.WindowsAzure.MobileServices
     {
         string GetPushHandle();
 
-        string GetUpdatedPushHandle();        
-        
-        JObject GetInstallation(string installationId, bool includeTemplates = false, string defaultChannelUri = null);
-        
-        JObject GetTemplates();
+        string GetUpdatedPushHandle();
+
+        JObject GetInstallation(string installationId, bool includeTemplates = false, bool templateBodyJson = false, string defaultChannelUri = null);
+
+        JObject GetTemplates(bool templateBodyJson = false);
     }
 }

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.Test/TestPlatform/MissingPushTestUtility.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.Test/TestPlatform/MissingPushTestUtility.cs
@@ -18,13 +18,13 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
         {
             throw new NotImplementedException();
         }
-       
-        public JObject GetInstallation(string installationId, bool includeTemplates = false, string defaultChannelUri = null)
+
+        public JObject GetInstallation(string installationId, bool includeTemplates = false, bool templateBodyJson = false, string defaultChannelUri = null)
         {
             throw new NotImplementedException();
         }
 
-        public JObject GetTemplates()
+        public JObject GetTemplates(bool templateBodyJson)
         {
             throw new NotImplementedException();
         }

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.Test/TestPlatform/PushTestUtility.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.Test/TestPlatform/PushTestUtility.cs
@@ -32,19 +32,19 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             return DefaultChannelUri.Replace('A', 'B');
         }
 
-        public JObject GetInstallation(string installationId, bool includeTemplates = false, string defaultChannelUri = null)
+        public JObject GetInstallation(string installationId, bool includeTemplates = false, bool templateBodyJson = false, string defaultChannelUri = null)
         {
             JObject installation = new JObject();
             installation[PushInstallationProperties.PUSHCHANNEL] = defaultChannelUri ?? DefaultChannelUri;
             installation[PushInstallationProperties.PLATFORM] = Platform.Instance.PushUtility.GetPlatform();
             if (includeTemplates)
             {
-                installation[PushInstallationProperties.TEMPLATES] = GetTemplates();
+                installation[PushInstallationProperties.TEMPLATES] = GetTemplates(templateBodyJson);
             }
             return installation;
         }
 
-        public JObject GetTemplates()
+        public JObject GetTemplates(bool templateBodyJson = false)
         {
             JObject templateHeaders = new JObject();
             templateHeaders["X-WindowsPhone-Target"] = "mpns/toast";

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/TestPlatform/PushTestUtility.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/TestPlatform/PushTestUtility.cs
@@ -31,19 +31,19 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             return DefaultChannelUri.Replace('A', 'B');
         }
 
-        public JObject GetInstallation(string installationId, bool includeTemplates = false, string defaultChannelUri = null)
+        public JObject GetInstallation(string installationId, bool includeTemplates = false, bool templateBodyJson = false, string defaultChannelUri = null)
         {
             JObject installation = new JObject();
             installation[PushInstallationProperties.PUSHCHANNEL] = defaultChannelUri ?? DefaultChannelUri;
             installation[PushInstallationProperties.PLATFORM] = Platform.Instance.PushUtility.GetPlatform();
             if (includeTemplates)
             {
-                installation[PushInstallationProperties.TEMPLATES] = GetTemplates();
+                installation[PushInstallationProperties.TEMPLATES] = GetTemplates(templateBodyJson);
             }
             return installation;
         }
 
-        public JObject GetTemplates()
+        public JObject GetTemplates(bool templateBodyJson = false)
         {
             JObject templateHeaders = new JObject();
             templateHeaders["X-WNS-Type"] = "wns/toast";

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/UnitTests/PushUnit.Test.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/UnitTests/PushUnit.Test.cs
@@ -44,9 +44,8 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
         public async Task RegisterAsync_ErrorEmptyChannelUri()
         {
             var mobileClient = new MobileServiceClient(DefaultServiceUri);
-            var exception = await AssertEx.Throws<ArgumentNullException>(
-           () => mobileClient.GetPush().RegisterAsync(""));
-            Assert.AreEqual(exception.Message, "Value cannot be null.\r\nParameter name: channelUri");
+            var exception = await AssertEx.Throws<ArgumentNullException>(() => mobileClient.GetPush().RegisterAsync(""));
+            Assert.AreEqual(exception.ParamName, "channelUri");
         }
 
         [AsyncTestMethod]

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/Properties/AssemblyInfo.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.WindowsAzure.MobileServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -13,6 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2013")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: Preserve]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/TestPlatform/PushTestUtility.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/TestPlatform/PushTestUtility.cs
@@ -15,9 +15,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
     {
         private const string DefaultDeviceToken =
             "<f6e7cd2 80fc5b5 d488f8394baf216506bc1bba 864d5b483d>";
-        const string BodyTemplate = "{\"aps\": {\"alert\":\"boo!\"}, \"extraprop\":\"($message)\"}";
         const string DefaultToastTemplateName = "templateForToastiOS";
-        readonly string[] DefaultTags = { "fooiOS", "bariOs" };
 
         public string GetPushHandle()
         {
@@ -29,29 +27,35 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             return DefaultDeviceToken.Replace('b', 'a').Replace('B', 'a');
         }
 
-        public JObject GetInstallation(string installationId, bool includeTemplates = false, string defaultChannelUri = null)
+        public JObject GetInstallation(string installationId, bool includeTemplates = false, bool templateBodyJson = false, string defaultChannelUri = null)
         {
             JObject installation = new JObject();
             installation[PushInstallationProperties.PUSHCHANNEL] = defaultChannelUri ?? TrimDeviceToken(DefaultDeviceToken);
             installation[PushInstallationProperties.PLATFORM] = Platform.Instance.PushUtility.GetPlatform();
             if (includeTemplates)
             {
-                installation[PushInstallationProperties.TEMPLATES] = GetTemplates();
+                installation[PushInstallationProperties.TEMPLATES] = GetTemplates(templateBodyJson);
             }
             return installation;
         }
 
-        public JObject GetTemplates()
+        public JObject GetTemplates(bool templateBodyJson = false)
         {
             JObject alert = new JObject();
             alert["alert"] = "$(message)";
             JObject aps = new JObject();
             aps["aps"] = alert;
+            JObject templateBody = new JObject();
+            templateBody["body"] = aps.ToString();
+            if (templateBodyJson)
+            {
+                templateBody["body"] = aps;
+            }
             JObject templates = new JObject();
-            templates[DefaultToastTemplateName] = aps;
+            templates[DefaultToastTemplateName] = templateBody;
             return templates;
         }
-        
+
         internal static string TrimDeviceToken(string deviceToken)
         {
             if (deviceToken == null)

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/UnitTests/PushUnit.Test.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/UnitTests/PushUnit.Test.cs
@@ -17,7 +17,6 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
 {
     [Tag("unit")]
     [Tag("push")]
-    
     public class PushUnit : TestBase
     {
         readonly string originalPushHandleDescription = "<f6e7cd2 80fc5b5 d488f8394baf216506bc1bba 864d5b483d>";
@@ -52,7 +51,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             NSData deviceToken = null;
             var exception = await AssertEx.Throws<ArgumentNullException>(
            () => mobileClient.GetPush().RegisterAsync(deviceToken));
-            Assert.AreEqual(exception.Message, "Argument cannot be null.\nParameter name: deviceToken");
+            Assert.AreEqual(exception.Message, "Value cannot be null.\nParameter name: deviceToken");
         }
 
         [AsyncTestMethod]
@@ -68,12 +67,26 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
         }
 
         [AsyncTestMethod]
-        public async Task RegisterAsync_WithTemplates()
+        public async Task RegisterAsync_WithTemplates_TemplateBodyString()
         {
             MobileServiceClient mobileClient = new MobileServiceClient(DefaultServiceUri);
 
             var expectedUri = string.Format("{0}{1}/{2}", DefaultServiceUri, InstallationsPath, mobileClient.GetPush().InstallationId);
             JObject templates = this.pushTestUtility.GetTemplates();
+            string installationRegistration = JsonConvert.SerializeObject(this.pushTestUtility.GetInstallation(mobileClient.GetPush().InstallationId, true));
+            var hijack = TestHttpDelegatingHandler.CreateTestHttpHandler(expectedUri, HttpMethod.Put, null, HttpStatusCode.OK, expectedRequestContent: installationRegistration);
+
+            mobileClient = new MobileServiceClient(DefaultServiceUri, hijack);
+            await mobileClient.GetPush().RegisterAsync(this.originalNSData, templates);
+        }
+
+        [AsyncTestMethod]
+        public async Task RegisterAsync_WithTemplates_TemplateBodyJSON()
+        {
+            MobileServiceClient mobileClient = new MobileServiceClient(DefaultServiceUri);
+
+            var expectedUri = string.Format("{0}{1}/{2}", DefaultServiceUri, InstallationsPath, mobileClient.GetPush().InstallationId);
+            JObject templates = this.pushTestUtility.GetTemplates(true);
             string installationRegistration = JsonConvert.SerializeObject(this.pushTestUtility.GetInstallation(mobileClient.GetPush().InstallationId, true));
             var hijack = TestHttpDelegatingHandler.CreateTestHttpHandler(expectedUri, HttpMethod.Put, null, HttpStatusCode.OK, expectedRequestContent: installationRegistration);
 

--- a/sdk/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/UnitTests/PushUnit.Test.cs
+++ b/sdk/test/Microsoft.WindowsAzure.MobileServices.iOS.Test/UnitTests/PushUnit.Test.cs
@@ -49,9 +49,8 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
         {
             var mobileClient = new MobileServiceClient(DefaultServiceUri);
             NSData deviceToken = null;
-            var exception = await AssertEx.Throws<ArgumentNullException>(
-           () => mobileClient.GetPush().RegisterAsync(deviceToken));
-            Assert.AreEqual(exception.Message, "Value cannot be null.\nParameter name: deviceToken");
+            var exception = await AssertEx.Throws<ArgumentNullException>(() => mobileClient.GetPush().RegisterAsync(deviceToken));
+            Assert.AreEqual(exception.ParamName, "deviceToken");
         }
 
         [AsyncTestMethod]


### PR DESCRIPTION
Notification Hub requires template body to be a string. Update register templates method to accept template body as string or JSON. Fix for #25