### PR TITLE
Replace #pragma in LogoutAsync method with a better fix

### DIFF
--- a/sdk/src/Microsoft.WindowsAzure.MobileServices/MobileServiceClient.cs
+++ b/sdk/src/Microsoft.WindowsAzure.MobileServices/MobileServiceClient.cs
@@ -376,12 +376,11 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <summary>
         /// Log a user out.
         /// </summary>
-#pragma warning disable 1998 // TODO: remove this suppression once the async/await issue is fixed
-        public async Task LogoutAsync()
+        public Task LogoutAsync()
         {
             this.CurrentUser = null;
+            return Task.FromResult(0);
         }
-#pragma warning restore 1998
 
         /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST.


### PR DESCRIPTION
#81 is not a good fix because of the compiler suppression. This fix would be a better one.