### PR TITLE
Add parameter for custom login title + clear cookies method

### DIFF
--- a/src/Microsoft.WindowsAzure.MobileServices.Android/Authentication/MobileServiceUIAuthentication.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices.Android/Authentication/MobileServiceUIAuthentication.cs
@@ -17,13 +17,22 @@ namespace Microsoft.WindowsAzure.MobileServices
 
         private Context context;
 
-        protected override Task<string> LoginAsyncOverride()
+        protected void Logout()
         {
+            WebAuthenticator.ClearCookies();
+        }
+
+        protected override Task<string> LoginAsyncOverride(string title = "")
+        { 
             var tcs = new TaskCompletionSource<string>();
 
             var auth = new WebRedirectAuthenticator (StartUri, EndUri);
             auth.ShowUIErrors = false;
             auth.ClearCookiesBeforeLogin = false;
+            if (!string.IsNullOrEmpty(title))
+            {
+                auth.Title = title;
+            }
 
             Intent intent = auth.GetUI (this.context);
 

--- a/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Authentication/MobileServiceSingleSignOnAuthentication.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Authentication/MobileServiceSingleSignOnAuthentication.cs
@@ -42,7 +42,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <returns>
         /// Task that will complete with the response string when the user has finished authentication.
         /// </returns>
-        protected override Task<string> LoginAsyncOverride()
+        protected override Task<string> LoginAsyncOverride(string title = "")
         {
             AuthenticationBroker broker = new AuthenticationBroker();
 

--- a/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Authentication/MobileServiceUIAuthentication.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Authentication/MobileServiceUIAuthentication.cs
@@ -32,7 +32,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <returns>
         /// Task that will complete with the response string when the user has finished authentication.
         /// </returns>
-        protected override Task<string> LoginAsyncOverride()
+        protected override Task<string> LoginAsyncOverride(string title = "")
         {
             AuthenticationBroker broker = new AuthenticationBroker();
 

--- a/src/Microsoft.WindowsAzure.MobileServices.iOS/Authentication/MobileServiceUIAuthentication.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices.iOS/Authentication/MobileServiceUIAuthentication.cs
@@ -26,14 +26,19 @@ namespace Microsoft.WindowsAzure.MobileServices
             this.view = view;
         }
 
-        protected override Task<string> LoginAsyncOverride()
+        protected override Task<string> LoginAsyncOverride(string title = "")
         {
             var tcs = new TaskCompletionSource<string>();
 
             var auth = new WebRedirectAuthenticator(StartUri, EndUri);
+
             auth.ShowUIErrors = false;
             auth.ClearCookiesBeforeLogin = false;
-
+            if (!string.IsNullOrEmpty(title))
+            {
+                auth.Title = title;
+            }
+            
             UIViewController c = auth.GetUI();
 
             UIViewController controller = null;

--- a/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceAuthentication.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceAuthentication.cs
@@ -158,6 +158,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <returns>
         /// Task that will complete with the response string when the user has finished authentication.
         /// </returns>
-        protected abstract Task<string> LoginAsyncOverride();
+        protected abstract Task<string> LoginAsyncOverride(string title = "");
+        
     }
 }

--- a/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceTokenAuthentication.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceTokenAuthentication.cs
@@ -53,7 +53,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <returns>
         /// Task that will complete with the response string when the user has finished authentication.
         /// </returns>
-        protected override Task<string> LoginAsyncOverride()
+        protected override Task<string> LoginAsyncOverride(string title = "")
         {
             string path = MobileServiceUrlBuilder.CombinePaths(LoginAsyncUriFragment, ProviderName);
             if (!string.IsNullOrEmpty(client.LoginUriPrefix))


### PR DESCRIPTION
- Add parameter for set custom login title.
- Add logout method for clear cookies. Actually, if a user logs in with oauth (like facebook) and logs out, with the second authentication he can't change his email/password (because it is cached in cookies). 