### PR TITLE
Adding name attribute to xamarin android login activity

### DIFF
--- a/e2etest/Android.E2ETest/LoginActivity.cs
+++ b/e2etest/Android.E2ETest/LoginActivity.cs
@@ -12,7 +12,7 @@ using Microsoft.WindowsAzure.MobileServices.TestFramework;
 
 namespace Microsoft.WindowsAzure.Mobile.Android.Test
 {
-    [Activity(Label = "Microsoft.WindowsAzure.Mobile.Android.Test", MainLauncher = true, Icon = "@drawable/icon")]
+    [Activity(Name="Microsoft.WindowsAzure.Mobile.Android.Test.LoginActivity", Label = "Microsoft.WindowsAzure.Mobile.Android.Test", MainLauncher = true, Icon = "@drawable/icon")]
     public class LoginActivity : Activity
     {
         static class Keys


### PR DESCRIPTION
Xamarin Android generates names for activities using an MD5 sum as of Android 5.1 [See Xamarin Release Notes] (https://developer.xamarin.com/releases/android/xamarin.android_5/xamarin.android_5.1/#Breaking_Changes). Using this name in our automation scripts is ugly, so I added the name field to the Activity attribute to provide a name that we can rely on in our scripts and that won't have to be updated after code changes.