### PR TITLE
Fixing activity name to not break app deployment

### DIFF
--- a/e2etest/Android.E2ETest/LoginActivity.cs
+++ b/e2etest/Android.E2ETest/LoginActivity.cs
@@ -12,7 +12,7 @@ using Microsoft.WindowsAzure.MobileServices.TestFramework;
 
 namespace Microsoft.WindowsAzure.Mobile.Android.Test
 {
-    [Activity(Name="Microsoft.WindowsAzure.Mobile.Android.Test.LoginActivity", Label = "Microsoft.WindowsAzure.Mobile.Android.Test", MainLauncher = true, Icon = "@drawable/icon")]
+    [Activity(Name="microsoft.windowsazure.mobile.android.test.LoginActivity", Label = "Microsoft.WindowsAzure.Mobile.Android.Test", MainLauncher = true, Icon = "@drawable/icon")]
     public class LoginActivity : Activity
     {
         static class Keys


### PR DESCRIPTION
Having a package name that starts with a capital letter when referencing the GCM package causes deployment to a device to fail. Fixing that.

http://forums.xamarin.com/discussion/16934/azure-messaging-problem-with-installing-apk
