### PR TITLE
Use 'as' keyword instead of explicit cast for MobileServiceClient type conversion to avoid potential InvalidCastException

### DIFF
--- a/src/Microsoft.WindowsAzure.MobileServices.Android/Push/Push.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices.Android/Push/Push.cs
@@ -26,7 +26,7 @@ namespace Microsoft.WindowsAzure.MobileServices
                 throw new ArgumentNullException("client");
             }
 
-            MobileServiceClient internalClient = (MobileServiceClient)client;
+            MobileServiceClient internalClient = client as MobileServiceClient;
             if (internalClient == null)
             {
                 throw new ArgumentException("Client must be a MobileServiceClient object");

--- a/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Push/Push.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Push/Push.cs
@@ -42,7 +42,7 @@ namespace Microsoft.WindowsAzure.MobileServices
                 tileId = PrimaryChannelId;
             }
 
-            MobileServiceClient internalClient = (MobileServiceClient)client;
+            MobileServiceClient internalClient = client as MobileServiceClient;
             if (internalClient == null)
             {
                 throw new ArgumentException("Client must be a MobileServiceClient object");

--- a/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/Push.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/Push.cs
@@ -32,7 +32,7 @@ namespace Microsoft.WindowsAzure.MobileServices
                 throw new ArgumentNullException("client");
             }
 
-            MobileServiceClient internalClient = (MobileServiceClient)client;
+            MobileServiceClient internalClient = client as MobileServiceClient;
             if (internalClient == null)
             {
                 throw new ArgumentException("Client must be a MobileServiceClient object");


### PR DESCRIPTION
`MobileServiceClient internalClient = (MobileServiceClient)client;` explicit type conversion could throw InvalidCastException in the runtime, 'as' type conversion will return null in this case.