### PR TITLE
Fix a storage container sas token issue for .NET45 e2etest app

### DIFF
--- a/e2etest/Net45.E2ETest/UI/TestPage.xaml.cs
+++ b/e2etest/Net45.E2ETest/UI/TestPage.xaml.cs
@@ -48,6 +48,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
 
             // Start a test run
             App.Harness.Reporter = this;
+            App.Harness.Settings.Custom["TestFrameworkStorageContainerSasToken"] = TestHarness.DecodeBase64String(App.Harness.Settings.Custom["TestFrameworkStorageContainerSasToken"]);
             Task.Factory.StartNew(() => App.Harness.RunAsync());
         }
 


### PR DESCRIPTION
This is a bugfix for .NET45 e2etest