### PR TITLE
Fix a race condition bug in unit test of PullAsync

### DIFF
--- a/unittest/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/Sync/MobileServiceSyncTable.Generic.Test.cs
+++ b/unittest/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/Sync/MobileServiceSyncTable.Generic.Test.cs
@@ -86,9 +86,9 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
 
             using (var cts = new CancellationTokenSource())
             {
-                // now pull
-                Task pullTask = table.PullAsync(null, null, null, cancellationToken: cts.Token);
+                // make sure cancellationToken is cancelled before calling PullAsync
                 cts.Cancel();
+                Task pullTask = table.PullAsync(null, null, null, cancellationToken: cts.Token);
 
                 var ex = await ThrowsAsync<Exception>(() => pullTask);
 


### PR DESCRIPTION
Unit test PullAsync_Cancels_WhenCancellationTokenIsCancelled() has a race condition of cancelling CancellationToken and invoking PullAsync(). The purpose of the test is to cancel CancellationToken before invoking PullAsync(), however the test is not implemented in the right way. 

The fix is very straightforward, simply calling CancellationToken.Cancel() before calling PullAsync().