### PR TITLE
Suppress a BCL nuget warning from Xamarin.Android and Xamarin.iOS project in VS

### DIFF
--- a/src/Microsoft.WindowsAzure.MobileServices.Android/Microsoft.WindowsAzure.Mobile.Ext.Android.csproj
+++ b/src/Microsoft.WindowsAzure.MobileServices.Android/Microsoft.WindowsAzure.Mobile.Ext.Android.csproj
@@ -168,6 +168,7 @@
     <ProjectReference Include="..\Microsoft.WindowsAzure.MobileServices\Microsoft.WindowsAzure.Mobile.csproj">
       <Project>{75557793-e36e-4190-8714-5bd2665859fb}</Project>
       <Name>Microsoft.WindowsAzure.Mobile</Name>
+      <Properties>SkipValidatePackageReferences=true</Properties>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.WindowsAzure.MobileServices.iOS/Microsoft.WindowsAzure.Mobile.Ext.iOS-Classic.csproj
+++ b/src/Microsoft.WindowsAzure.MobileServices.iOS/Microsoft.WindowsAzure.Mobile.Ext.iOS-Classic.csproj
@@ -170,6 +170,7 @@
     <ProjectReference Include="..\Microsoft.WindowsAzure.MobileServices\Microsoft.WindowsAzure.Mobile.csproj">
       <Project>{75557793-E36E-4190-8714-5BD2665859FB}</Project>
       <Name>Microsoft.WindowsAzure.Mobile</Name>
+      <Properties>SkipValidatePackageReferences=true</Properties>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Disable nuget package reference validation of bcl in Xamarin.Android and Xamarin.iOS project to get rid of warning "All projects referencing Microsoft.WindowsAzure.Mobile.csproj must install nuget package Microsoft.Bcl.Build." in VS.

I learned how to fix it from [this](http://stackoverflow.com/questions/17180268/warning-all-projects-referencing-myproject-csproj-must-install-nuget-package-m) stackoverflow question.