### PR TITLE
[E2ETest][UWP]Adding protocol activation to UWP E2ETest

### DIFF
--- a/e2etest/E2ETestFramework/Helper/TestConfigHelper.cs
+++ b/e2etest/E2ETestFramework/Helper/TestConfigHelper.cs
@@ -61,6 +61,33 @@ namespace Microsoft.WindowsAzure.MobileServices.TestFramework
                 harness.Settings.ManualMode = false;
             }
         }
+        /// <summary>
+         /// Set the test harness configuration for manual or auto mode. Sets the app to  auto mode 
+         /// if more than 2 or more arguments are passed.
+         /// </summary>
+         /// <param name="harness">Test Harness object to be configured</param>
+         /// <param name="queryString">Query string containing the parameters to be used</param>
+        public static void SetAutoConfigQueryString(this TestHarness harness, String queryString)
+        {
+            harness.Settings.ManualMode = true;
+
+            if (String.IsNullOrEmpty(queryString))
+            {
+                return;
+            }
+
+            var args = parseQueryString(queryString);
+
+            if (args.Count > 0)
+            {
+                harness.Settings.Custom["MobileServiceRuntimeUrl"] = getArgumentValue("url", args);
+                harness.Settings.Custom["TestFrameworkStorageContainerUrl"] = getArgumentValue("storageurl", args);
+                harness.Settings.Custom["TestFrameworkStorageContainerSasToken"] = getArgumentValue("storagesastoken", args);
+                harness.Settings.Custom["RuntimeVersion"] = getArgumentValue("runtimeversion", args);
+                harness.Settings.TagExpression = getArgumentValue("tags", args);
+                harness.Settings.ManualMode = false;
+            }
+        }
 
         private static string getArgumentValue(string name, Dictionary<string, string> args)
         {
@@ -86,6 +113,40 @@ namespace Microsoft.WindowsAzure.MobileServices.TestFramework
 
                 string argName = arg.Substring(0, index).ToLower();
                 string argVal = arg.Substring(index + 1);
+                parameters.Add(argName, argVal);
+            }
+            return parameters;
+        }
+
+        /// <summary>
+        /// Parse the query string received
+        /// </summary>
+        /// <param name="query">String containing the query string</param>
+        /// <returns>Dictionary representing the arguments collection</returns>
+        private static Dictionary<string, string> parseQueryString(string query)
+        {
+            if (String.IsNullOrEmpty(query))
+            {
+                throw new ArgumentException("Query string must not be empty or null");
+            }
+
+            if (query.IndexOf("?") == 0)
+            {
+                query = query.Substring(1);
+            }
+
+            var args = query.Split('&');
+
+            var parameters = new Dictionary<string, string>();
+            foreach (var arg in args)
+            {
+                int index = arg.IndexOf('=');
+
+                if (index < 0 || index + 1 == arg.Length || index == 0)
+                    continue;
+
+                string argName = arg.Substring(0, index).ToLower();
+                string argVal = Uri.UnescapeDataString(arg.Substring(index + 1));
                 parameters.Add(argName, argVal);
             }
             return parameters;

--- a/e2etest/UWP.E2ETest/App.xaml.cs
+++ b/e2etest/UWP.E2ETest/App.xaml.cs
@@ -11,6 +11,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using Microsoft.WindowsAzure.MobileServices.TestFramework;
 
+
 namespace Microsoft.WindowsAzure.MobileServices.Test
 {
     /// <summary>
@@ -74,7 +75,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
 
                 Harness.SetAutoConfig(args.Arguments);
 
-                if(Harness.Settings.ManualMode)
+                if (Harness.Settings.ManualMode)
                 {
                     rootFrame.Navigate(typeof(MainPage));
                 }
@@ -97,6 +98,39 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             Window.Current.Activate();
         }
 
+        protected override void OnActivated(IActivatedEventArgs args)
+        {
+            
+            if (args.Kind == ActivationKind.Protocol)
+            {
+                ProtocolActivatedEventArgs protocolArgs = args as ProtocolActivatedEventArgs;
+
+                Frame content = Window.Current.Content as Frame;
+                if (content == null)
+                {
+                    content = new Frame();
+                    Harness.SetAutoConfigQueryString(protocolArgs.Uri.Query);
+
+                    if (Harness.Settings.ManualMode)
+                    {
+                        content.Navigate(typeof(MainPage));
+                    }
+                    else
+                    {
+                        content.Navigate(typeof(TestPage));
+                    }
+
+                    Window.Current.Content = content;
+                }
+
+                if (content.Content == null)
+                {
+                    content.Navigate(typeof(MainPage), args);
+                }
+            }
+            Window.Current.Activate();
+            base.OnActivated(args);
+        }
         /// <summary>
         /// Invoked when Navigation to a certain page fails
         /// </summary>

--- a/e2etest/UWP.E2ETest/Package.appxmanifest
+++ b/e2etest/UWP.E2ETest/Package.appxmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
   <Identity Name="Microsoft.WindowsAzure.Mobile.UWP.Test" Publisher="CN=zumo" Version="1.0.0.0" />
-  <mp:PhoneIdentity PhoneProductId="Microsoft.WindowsAzure.Mobile.UWP.Phone.Test" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <mp:PhoneIdentity PhoneProductId="090c4fbc-84b7-4f81-bc46-54d2ee20057d" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>UWP.E2ETest</DisplayName>
     <PublisherDisplayName>zumo</PublisherDisplayName>
@@ -20,6 +20,13 @@
         </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="zumoe2e-uwp">
+            <uap:Logo>Assets\Logo.png</uap:Logo>
+          </uap:Protocol>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
   <Capabilities>


### PR DESCRIPTION
By adding <uap:Protocol Name="zumoe2e-uwp"> the UWP app can now be launched using the powershell command: start-process zumoe2e-uwp: with the configuration settings passed in as query string parameters. 

Also fixed error with PhoneIdentity change