### PR TITLE
[e2etest] Use OneDrive SDK for client directed MSA login test instead of Live SDK.

### DIFF
--- a/e2etest/WindowsStore.E2ETest/Functional/ClientSDKLoginTests.cs
+++ b/e2etest/WindowsStore.E2ETest/Functional/ClientSDKLoginTests.cs
@@ -42,11 +42,11 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
 
                     MobileServiceUser user = await this.GetClient().LoginAsync(MobileServiceAuthenticationProvider.MicrosoftAccount, accessToken);
 
-                    Log(string.Format("Log in with Microsoft Account succeeded - userId {0}", user.UserId));
+                    Log(string.Format("Log in with Microsoft Account OneDrive SDK succeeded - userId {0}", user.UserId));
                 }
                 else
                 {
-                    Assert.Fail("Log in with Live SDK failed");
+                    Assert.Fail("Log in with Microsoft Account OneDrive SDK failed");
                 }
             }
             catch (Exception exception)
@@ -55,7 +55,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
                                                 exception.GetType().ToString(),
                                                 exception.Message,
                                                 exception.StackTrace));
-                Assert.Fail("Log in with Live SDK failed");
+                Assert.Fail("Log in with Microsoft Account OneDrive SDK failed");
             }
         }
 

--- a/e2etest/WindowsStore.E2ETest/Win8.E2ETest.csproj
+++ b/e2etest/WindowsStore.E2ETest/Win8.E2ETest.csproj
@@ -188,12 +188,21 @@
     </SDKReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Live">
-      <HintPath>..\..\packages\LiveSDK.5.6.2\WindowsXAML\Microsoft.Live.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.21.301221612\lib\netcore45\Microsoft.IdentityModel.Clients.ActiveDirectory.winmd</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\netcore45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="OneDriveSdk, Version=1.1.47.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OneDriveSDK.1.1.47\lib\win81\OneDriveSdk.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OneDriveSdk.WinStore, Version=1.1.47.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OneDriveSDK.1.1.47\lib\win81\OneDriveSdk.WinStore.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SQLitePCL, Version=3.8.7.2, Culture=neutral, PublicKeyToken=bddade01e9c850c5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/e2etest/WindowsStore.E2ETest/packages.config
+++ b/e2etest/WindowsStore.E2ETest/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LiveSDK" version="5.6.2" targetFramework="win81" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.0" targetFramework="win81" />
   <package id="Microsoft.Azure.Mobile.Client.SQLiteStore" version="2.0.0" targetFramework="win81" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="win81" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="win81" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.21.301221612" targetFramework="win81" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="win81" />
+  <package id="Microsoft.OneDriveSDK" version="1.1.47" targetFramework="win81" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="win81" />
   <package id="SQLitePCL" version="3.8.7.2" targetFramework="win81" />
 </packages>


### PR DESCRIPTION
[Live SDK](https://github.com/liveservices/LiveSDK) is going to be replaced by [OneDrive SDK](https://github.com/OneDrive/onedrive-sdk-csharp), so it's time to drop Live SDK and pick up OneDrive SDK in e2etest. **OneDrive SDK only supports Windows 8.1, WindowsPhone 8.1 and UWP.** 

This PR fixes the client directed login flow for Microsoft Account using OneDrive SDK. 

PS: OneDrive [wiki](https://github.com/OneDrive/onedrive-sdk-csharp/blob/master/docs/auth.md#microsoft-account-msa-authentication) explains it very well how to use it's authentication API.

@pragnagopa @brettsam Can you take a look?