### PR TITLE
[Auth] Fix a bug of LoginAsync with parameters with non-single-sign-on

### DIFF
--- a/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Extensions/SingleSignOnExtensions.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Extensions/SingleSignOnExtensions.cs
@@ -109,7 +109,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         {
             if (!useSingleSignOn)
             {
-                return client.LoginAsync(provider);
+                return client.LoginAsync(provider, parameters);
             }
 
             MobileServiceSingleSignOnAuthentication auth = new MobileServiceSingleSignOnAuthentication(client, provider, parameters);


### PR DESCRIPTION
`LoginAsync(this IMobileServiceClient client, string provider, bool useSingleSignOn, IDictionary<string, string> parameters)` overload in Windows Store extension ignores `IDictionary<string, string> parameters` when `useSingleSignOn` is false. This bug would cause non-single-sign-on login missing url parameters on Windows Store platform. I found this bug from running [Windows Store 8.1 AAD login e2etest](https://github.com/Azure/azure-mobile-apps-net-client/blob/master/e2etest/WindowsStore.E2ETest/Functional/LoginTests.cs#L73). 

@pragnagopa @fabiocav Can you kindly review this?