### PR TITLE
[e2etest] Remove client LoginAsync() uri parameter "prompt=consent" of Google account

### DIFF
--- a/e2etest/Android.E2ETest/LoginActivity.cs
+++ b/e2etest/Android.E2ETest/LoginActivity.cs
@@ -192,8 +192,7 @@ namespace Microsoft.WindowsAzure.Mobile.Android.Test
             var user = await client.LoginAsync(this, MobileServiceAuthenticationProvider.Google,
                 new Dictionary<string, string>()
                 {
-                    { "access_type", "offline" },
-                    { "prompt", "consent" } // Force prompt window of Google offline scope in login
+                    { "access_type", "offline" }
                 });
             string authToken = user.MobileServiceAuthenticationToken;
             this.loginTestResult.Text = "Google LoginAsync succeeded. UserId: " + user.UserId;

--- a/e2etest/WindowsPhone8.E2ETest/Functional/LoginTests.cs
+++ b/e2etest/WindowsPhone8.E2ETest/Functional/LoginTests.cs
@@ -168,8 +168,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             // Firstly, login user with Google account with offline permission
             MobileServiceUser user = await client.LoginAsync(MobileServiceAuthenticationProvider.Google, new Dictionary<string, string>()
             {
-                { "access_type", "offline" },
-                { "prompt", "consent" } // Force prompt window of Google offline scope in login
+                { "access_type", "offline" }
             });
 
             // Secondly, refresh user using refresh token
@@ -206,8 +205,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             // Last, login user with Google offline scope again
             MobileServiceUser user2 = await client.LoginAsync(MobileServiceAuthenticationProvider.Google, new Dictionary<string, string>()
             {
-                { "access_type", "offline" },
-                { "prompt", "consent" } // Force prompt window of Google offline scope in login
+                { "access_type", "offline" }
             });
 
             // Refresh user should work this time

--- a/e2etest/WindowsStore.E2ETest/Functional/LoginTests.cs
+++ b/e2etest/WindowsStore.E2ETest/Functional/LoginTests.cs
@@ -165,8 +165,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             MobileServiceUser user = await client.LoginAsync(MobileServiceAuthenticationProvider.Google, useSingleSignOn, 
                 new Dictionary<string, string>()
                 {
-                    { "access_type", "offline" },
-                    { "prompt", "consent" } // Force prompt window of Google offline scope in login
+                    { "access_type", "offline" }
                 });
 
             // save user.MobileServiceAuthenticationToken value for later use
@@ -211,8 +210,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             MobileServiceUser sameUser = await client.LoginAsync(MobileServiceAuthenticationProvider.Google, useSingleSignOn, 
                 new Dictionary<string, string>()
                 {
-                    { "access_type", "offline" },
-                    { "prompt", "consent" } // Force prompt window of Google offline scope in login
+                    { "access_type", "offline" }
                 });
             string authToken2 = sameUser.MobileServiceAuthenticationToken;
 

--- a/e2etest/iOS.E2ETest/UI/LoginViewController.cs
+++ b/e2etest/iOS.E2ETest/UI/LoginViewController.cs
@@ -136,8 +136,7 @@ namespace Microsoft.WindowsAzure.Mobile.iOS.Test
             MobileServiceUser user = await client.LoginAsync(this, MobileServiceAuthenticationProvider.Google,
                 new Dictionary<string, string>()
                 {
-                    { "access_type", "offline" },
-                    { "prompt", "consent" } // Force prompt window of Google offline scope in login
+                    { "access_type", "offline" }
                 });
             string authToken = user.MobileServiceAuthenticationToken;
 


### PR DESCRIPTION
We add "prompt=consent" in the url parameter on login call to Google as a way to **force** Google showing up the user consent page during web authentication. This is supposed to be a workaround. As App Service Easy-Auth backend fixed the internal issue, we don't need this workaround any more.