### PR TITLE
[e2etest] Add backend info to test result

### DIFF
--- a/e2etest/E2ETestFramework/Framework/MasterTestResult.cs
+++ b/e2etest/E2ETestFramework/Framework/MasterTestResult.cs
@@ -12,6 +12,9 @@ namespace Microsoft.WindowsAzure.MobileServices.TestFramework
         [JsonProperty("full_name")]
         public string FullName { get; set; }
 
+        [JsonProperty("backend")]
+        public string Backend { get; set; }
+
         [JsonProperty("outcome")]
         public string Outcome { get; set; }
 

--- a/e2etest/E2ETestFramework/Framework/TestHarness.cs
+++ b/e2etest/E2ETestFramework/Framework/TestHarness.cs
@@ -297,7 +297,8 @@ namespace Microsoft.WindowsAzure.MobileServices.TestFramework
                             // upload test result summary to blob container
                             var masterResult = new MasterTestResult()
                             {
-                                FullName = this.Platform + "-" + Settings.Custom["RuntimeVersion"],
+                                FullName = Settings.Custom["RuntimeVersion"] + "-" + this.Platform,
+                                Backend = Settings.Custom["RuntimeVersion"],
                                 Outcome = Failures > 0 ? "Failed" : "Passed",
                                 TotalCount = testRun.TestCount,
                                 Passed = filteredTestCount - Failures,
@@ -305,7 +306,7 @@ namespace Microsoft.WindowsAzure.MobileServices.TestFramework
                                 Skipped = testRun.TestCount - filteredTestCount,
                                 StartTime = RunStartTime,
                                 EndTime = DateTime.UtcNow,
-                                ReferenceUrl = this.Platform + "-detail.json"
+                                ReferenceUrl = Settings.Custom["RuntimeVersion"] + "-" + this.Platform + "-detail.json"
                             };
 
                             // upload test suite result to sunlight blob container


### PR DESCRIPTION
1. PR #170 modifies the test result json file name without updating the actual file content. This PR fixes this.
2. Adding a new property "backend" to test result json file