### PR TITLE
Update Xamarin.Auth submodule

### DIFF
--- a/e2etest/UWP.E2ETest/UWP.E2ETest.csproj
+++ b/e2etest/UWP.E2ETest/UWP.E2ETest.csproj
@@ -207,7 +207,7 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.UWP.2015, Version=3.12.0">
+    <SDKReference Include="SQLite.UWP.2015, Version=3.13.0">
       <Name>SQLite for Universal Windows Platform</Name>
     </SDKReference>
   </ItemGroup>

--- a/e2etest/WindowsStore.E2ETest/Win8.E2ETest.csproj
+++ b/e2etest/WindowsStore.E2ETest/Win8.E2ETest.csproj
@@ -183,7 +183,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WinRT81, Version=3.12.0">
+    <SDKReference Include="SQLite.WinRT81, Version=3.13.0">
       <Name>SQLite for Windows Runtime %28Windows 8.1%29</Name>
     </SDKReference>
   </ItemGroup>

--- a/unittest/Microsoft.WindowsAzure.MobileServices.SQLiteStore.WindowsPhone8.Test/Microsoft.WindowsAzure.Mobile.SQLiteStore.WP8.Test.csproj
+++ b/unittest/Microsoft.WindowsAzure.MobileServices.SQLiteStore.WindowsPhone8.Test/Microsoft.WindowsAzure.Mobile.SQLiteStore.WP8.Test.csproj
@@ -218,7 +218,7 @@
     <Folder Include="UnitTests\" />
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="SQLite.WP80, Version=3.12.0">
+    <SDKReference Include="SQLite.WP80, Version=3.13.0">
       <Name>SQLite for Windows Phone</Name>
     </SDKReference>
   </ItemGroup>

--- a/unittest/Microsoft.WindowsAzure.MobileServices.SQLiteStore.WindowsStore.Test/Microsoft.WindowsAzure.Mobile.SQLiteStore.Win8.Test.csproj
+++ b/unittest/Microsoft.WindowsAzure.MobileServices.SQLiteStore.WindowsStore.Test/Microsoft.WindowsAzure.Mobile.SQLiteStore.Win8.Test.csproj
@@ -196,7 +196,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WinRT81, Version=3.12.0">
+    <SDKReference Include="SQLite.WinRT81, Version=3.13.0">
       <Name>SQLite for Windows Runtime %28Windows 8.1%29</Name>
     </SDKReference>
   </ItemGroup>

--- a/unittest/Microsoft.WindowsAzure.MobileServices.Test/Microsoft.WindowsAzure.Mobile.Test.csproj
+++ b/unittest/Microsoft.WindowsAzure.MobileServices.Test/Microsoft.WindowsAzure.Mobile.Test.csproj
@@ -25,7 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisAdditionalOptions>
      /assemblyCompareMode:StrongNameIgnoringVersion      
     </CodeAnalysisAdditionalOptions>


### PR DESCRIPTION
Moving to latest commit in Xamarin.Auth submodule to address namespace collisions introduced in Xamarin 6.1.0