### PR TITLE
Resolves #186 - MobileServiceContractResolver is now threadsafe.

### DIFF
--- a/unittest/Microsoft.WindowsAzure.MobileServices.Test.Unit/Microsoft.WindowsAzure.Mobile.Test.Unit.csproj
+++ b/unittest/Microsoft.WindowsAzure.MobileServices.Test.Unit/Microsoft.WindowsAzure.Mobile.Test.Unit.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Extensions\ExceptionExtensions.Test.cs" />
     <Compile Include="Extensions\JTokenExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Table\MobileServiceContractResolverTests.cs" />
     <Compile Include="Table\MobileServiceSyncContextTests.cs" />
     <Compile Include="Table\Query\MobileServiceTableQueryDescriptionTests.cs" />
     <Compile Include="Table\Sync\MobileServiceSyncTableTests.cs" />

--- a/unittest/Microsoft.WindowsAzure.MobileServices.Test.Unit/Table/MobileServiceContractResolverTests.cs
+++ b/unittest/Microsoft.WindowsAzure.MobileServices.Test.Unit/Table/MobileServiceContractResolverTests.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.MobileServices.Test.Unit.Table
+{
+    [TestClass]
+    public class MobileServiceContractResolverTests
+    {
+        [TestMethod]
+        public void ResolveContractIsThreadSafe()
+        {
+            const int iterationCount = 100;
+
+            for (int i = 0; i < iterationCount; i++)
+            {
+                MobileServiceContractResolver contractResolver = new MobileServiceContractResolver();
+                Func<JsonContract> resolveContract = () => contractResolver.ResolveContract(typeof(PocoType));
+
+                Task t1 = Task.Run(resolveContract);
+                Task t2 = Task.Run(resolveContract);
+                Task.WhenAll(t1, t2).Wait();
+            }
+        }
+
+        [TestMethod]
+        public void ResolveTableNameIsThreadSafe()
+        {
+            const int iterationCount = 100;
+
+            for (int i = 0; i < iterationCount; i++)
+            {
+                MobileServiceContractResolver contractResolver = new MobileServiceContractResolver();
+                Action resolveTableName = () => contractResolver.ResolveTableName(typeof(PocoType));                
+
+                Task t1 = Task.Run(resolveTableName);
+                Task t2 = Task.Run(resolveTableName);
+                Task.WhenAll(t1, t2).Wait();                
+            }
+        }
+    }
+}


### PR DESCRIPTION
All the thread safety issues appear to be around the jsonPropertyCache, so I just serialized the writes to the cache and made sure that enumeration was done from a copy. Considering we're already in edge case land I did not go as far as comparing the JsonContract instances returned because there is no convenient equals operation to piggy back onto. But I did inspect the code path and I'm reasonably confident that two racing ResolveContract(..) calls are idempotent.