### PR TITLE
Fix MobileServiceContractResolver reentrancy issue.

### DIFF
--- a/src/Microsoft.WindowsAzure.MobileServices/Table/Serialization/MobileServiceContractResolver.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Table/Serialization/MobileServiceContractResolver.cs
@@ -202,7 +202,7 @@ namespace Microsoft.WindowsAzure.MobileServices
 
             try
             {
-                jsonPropertyCacheLock.EnterReadLock();
+                jsonPropertyCacheLock.EnterUpgradeableReadLock();
                 
                 if (!this.jsonPropertyCache.TryGetValue(member, out property))
                 {
@@ -212,7 +212,7 @@ namespace Microsoft.WindowsAzure.MobileServices
             }
             finally
             {
-                jsonPropertyCacheLock.ExitReadLock();
+                jsonPropertyCacheLock.ExitUpgradeableReadLock();
             }
 
             return property;


### PR DESCRIPTION
The same thread can enter a read lock and then make a call to ResolveContract. This can result in an attempt to acquire a write lock, so the read lock for this code path needs to be upgradable.