### PR TITLE
Code Change to ignore pulled record if operation queue contains same pulled record in it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ unittest/**/AppPackages/*
 .vs/
 e2etest/*/project.lock.json
 e2etest/*/*.nuget.targets
+/src/Microsoft.WindowsAzure.MobileServices.Net45/Microsoft.Azure.Mobile.Client.Ex.snk
+/src/Microsoft.WindowsAzure.MobileServices/Microsoft.Azure.Mobile.Client.Ex.snk

--- a/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/Queue/Actions/PullAction.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/Queue/Actions/PullAction.cs
@@ -107,6 +107,12 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
                     continue;
                 }
 
+                var pendingOperation = await this.OperationQueue.GetOperationByItemIdAsync(this.Table.TableName, id);
+                if (pendingOperation != null)
+                {
+                    continue;
+                }
+
                 DateTimeOffset updatedAt = this.Reader.GetUpdatedAt(item).GetValueOrDefault(Epoch).ToUniversalTime();
                 strategy.SetUpdateAt(updatedAt);
 

--- a/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/Queue/OperationQueue.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/Queue/OperationQueue.cs
@@ -90,7 +90,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
             return this.itemLocks.Acquire(id, cancellationToken);
         }
 
-        public async Task<MobileServiceTableOperation> GetOperationByItemIdAsync(string tableName, string itemId)
+        public virtual async Task<MobileServiceTableOperation> GetOperationByItemIdAsync(string tableName, string itemId)
         {
             MobileServiceTableQueryDescription query = CreateQuery();
             query.Filter = new BinaryOperatorNode(BinaryOperatorKind.And,
@@ -153,7 +153,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
         {
             try
             {
-                MobileServiceTableOperation op = await GetOperationAsync(id);                
+                MobileServiceTableOperation op = await GetOperationAsync(id);
                 if (op == null || op.Version != version)
                 {
                     return false;
@@ -163,7 +163,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
 
                 // Change the operation state back to pending since this is a newly updated operation without any conflicts
                 op.State = MobileServiceTableOperationState.Pending;
-                
+
                 // if the operation type is delete then set the item property in the Operation table
                 if (op.Kind == MobileServiceTableOperationKind.Delete)
                 {

--- a/unittest/Microsoft.WindowsAzure.MobileServices.Test.Unit/Table/Sync/Queue/Actions/PullActionTests.cs
+++ b/unittest/Microsoft.WindowsAzure.MobileServices.Test.Unit/Table/Sync/Queue/Actions/PullActionTests.cs
@@ -53,6 +53,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test.Unit.Table.Sync.Queue.Actio
             });
             this.opQueue.Setup(q => q.LockTableAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult<IDisposable>(null));
             this.opQueue.Setup(q => q.CountPending(It.IsAny<string>())).Returns(Task.FromResult(0L));
+            this.opQueue.Setup(q => q.GetOperationByItemIdAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult<MobileServiceTableOperation>(null));
             this.table.SetupSequence(t => t.ReadAsync(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<MobileServiceFeatures>()))
                       .Returns(Task.FromResult(QueryResult.Parse(result, null, false)))
                       .Returns(Task.FromResult(QueryResult.Parse(new JArray(), null, false)));
@@ -162,6 +163,67 @@ namespace Microsoft.WindowsAzure.MobileServices.Test.Unit.Table.Sync.Queue.Actio
             };
         }
 
+        [TestMethod]
+        public async Task DoesNotUpsertAnObject_IfRecordIsPresentInOperationQueue()
+        {
+            var query = new MobileServiceTableQueryDescription("test");
+            var action = new PullAction(this.table.Object, MobileServiceTableKind.Table, this.context.Object, null, query, null, null, this.opQueue.Object, this.settings.Object, this.store.Object, MobileServiceRemoteTableOptions.All, pullOptions: null, reader: null, cancellationToken: CancellationToken.None);
+
+            //// item with insert operation from server
+            var insertItemWithPendingOperation = new JObject() { { "id", "abc" }, { "text", "has pending operation" } };
+
+            //// item with update operation from server
+            var updateItemWithPendingOperation = new JObject() { { "id", "abc2" }, { "text", "has pending operation" } };
+
+            //// item with delete operation from server
+            var deleteItemWithPendingOperation = new JObject() { { "id", "abc3" }, { "text", "has pending operation" } };
+
+            //// item with no pending operation from server
+            var itemWithNoPendingOperation = new JObject() { { "id", "abc4" }, { "text", "has no pending operation" } };
+
+            var result = new JArray(new[]{
+                insertItemWithPendingOperation,
+                updateItemWithPendingOperation,
+                deleteItemWithPendingOperation,
+                itemWithNoPendingOperation
+            });
+
+            this.opQueue.Setup(q => q.LockTableAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult<IDisposable>(null));
+            this.opQueue.Setup(q => q.CountPending(It.IsAny<string>())).Returns(Task.FromResult(0L));
+            this.opQueue.Setup(q => q.GetOperationByItemIdAsync(It.IsAny<string>(), It.IsAny<string>())).Returns((string tableName, string id) =>
+            {
+                if (id.Equals("abc"))
+                    return Task.FromResult<MobileServiceTableOperation>(new InsertOperation(tableName, MobileServiceTableKind.Table, id));
+                else if (id.Equals("abc2"))
+                    return Task.FromResult<MobileServiceTableOperation>(new UpdateOperation(tableName, MobileServiceTableKind.Table, id));
+                else if (id.Equals("abc3"))
+                    return Task.FromResult<MobileServiceTableOperation>(new DeleteOperation(tableName, MobileServiceTableKind.Table, id));
+                else
+                    return Task.FromResult<MobileServiceTableOperation>(null);
+            });
+
+            //// below two reads correspond to first and second page from the server
+            this.table.SetupSequence(t => t.ReadAsync(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<MobileServiceFeatures>()))
+                      .Returns(Task.FromResult(QueryResult.Parse(result, null, false)))
+                      .Returns(Task.FromResult(QueryResult.Parse(new JArray(), null, false)));
+
+            this.store.Setup(s => s.UpsertAsync("test", It.IsAny<IEnumerable<JObject>>(), true))
+                      .Returns(Task.FromResult(0))
+                      .Callback<string, IEnumerable<JObject>, bool>((tableName, items, fromServer) =>
+                      {
+                          Assert.AreEqual(1, items.Count());
+                          Assert.AreEqual(itemWithNoPendingOperation, items.First());
+                      });
+
+            await action.ExecuteAsync();
+
+            store.VerifyAll();
+            opQueue.VerifyAll();
+            table.VerifyAll();
+
+            store.Verify(s => s.DeleteAsync("test", It.IsAny<IEnumerable<string>>()), Times.Never(), "There shouldn't be any call to delete");
+        }
+
         private async Task TestIncrementalSync(MobileServiceTableQueryDescription query, JArray result, DateTime maxUpdatedAt, bool savesMax, string firstQuery, string secondQuery)
         {
             var action = new PullAction(this.table.Object, MobileServiceTableKind.Table, this.context.Object,
@@ -175,6 +237,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test.Unit.Table.Sync.Queue.Actio
 
             if (result.Any())
             {
+                this.opQueue.Setup(q => q.GetOperationByItemIdAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult<MobileServiceTableOperation>(null));
                 this.table.Setup(t => t.ReadAsync(secondQuery, It.IsAny<IDictionary<string, string>>(), It.IsAny<MobileServiceFeatures>()))
                           .Returns(Task.FromResult(QueryResult.Parse(new JArray(), null, false)));
             }


### PR DESCRIPTION
**Changelog for azure-mobile-apps-net-client**
**********************************************

** Includes code changes for avoiding local store update with pulled records if operation queue already contains same pulled record in it. Added new test method also for the changes done.
** Files modified are :
  1. PullAction.cs - Added check for existing operation record same as pulled record to ignore local store update in ProcessAll method (Line - 110)
  2.  OperationQueue.cs -  Made GetOperationByItemIdAsync method as virtual so that it can be mocked in the related unit test (Line - 93).
  3.  PullActionTests.cs - Added test method DoNotUpdateRecord_IfRecordIsPresentInOperationQueue for code changes done in PushAction.cs (Line 167 - 206).
			 - Modified existing test method DoesNotUpsertAnObject_IfItDoesNotHaveAnId (Line - 56) and TestIncrementalSync (Line - 221) to include mock for 						   GetOperationByItemIdAsync method of OperationQueue class.	

***********************************************