### PR TITLE
Implementing addition of custom headers for login process

### DIFF
--- a/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Extensions/MobileServiceClientExtensions.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices.WindowsStore/Extensions/MobileServiceClientExtensions.cs
@@ -58,6 +58,29 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <param name="provider">
         /// Authentication provider to use.
         /// </param>
+        /// <param name="parameters">
+        /// Provider specific extra parameters that are sent as query string parameters to login endpoint.
+        /// </param>
+        /// <param name="customHeaders">
+        /// User specified custom headers to send with request
+        /// </param>
+        /// <returns>
+        /// Task that will complete when the user has finished authentication.
+        /// </returns>
+        public static Task<MobileServiceUser> LoginAsync(this IMobileServiceClient client, MobileServiceAuthenticationProvider provider, IDictionary<string, string> parameters, IDictionary<string, string> customHeaders)
+        {
+            return LoginAsync(client, provider.ToString(), parameters, customHeaders);
+        }
+
+        /// <summary>
+        /// Log a user into a Mobile Services application given a provider name.
+        /// </summary>
+        /// <param name="client">
+        /// The client.
+        /// </param>
+        /// <param name="provider">
+        /// Authentication provider to use.
+        /// </param>
         /// <returns>
         /// Task that will complete when the user has finished authentication.
         /// </returns>
@@ -78,12 +101,16 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <param name="parameters">
         /// Provider specific extra parameters that are sent as query string parameters to login endpoint.
         /// </param>
+        /// <param name="customHeaders">
+        /// User specified custom headers to send with request
+        /// </param>
         /// <returns>
         /// Task that will complete when the user has finished authentication.
         /// </returns>
-        public static Task<MobileServiceUser> LoginAsync(this IMobileServiceClient client, string provider, IDictionary<string, string> parameters)
+        public static Task<MobileServiceUser> LoginAsync(this IMobileServiceClient client, string provider, IDictionary<string, string> parameters, IDictionary<string, string> customHeaders)
         {
             MobileServiceUIAuthentication auth = new MobileServiceUIAuthentication(client, provider, parameters);
+            auth.SetCustomHeaders(customHeaders);
             return auth.LoginAsync();
         }
 

--- a/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceAuthentication.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceAuthentication.cs
@@ -87,6 +87,16 @@ namespace Microsoft.WindowsAzure.MobileServices
         }
 
         /// <summary>
+        /// Set custom headers to be executed with requests
+        /// </summary>
+        /// <param name="customHeaders">Custom headers sent with the request as required by user.</param>
+        public void SetCustomHeaders(IDictionary<string, string> customHeaders)
+        {
+            if (customHeaders != null && customHeaders.Count > 0)
+                CustomHeaders = customHeaders;
+        }
+
+        /// <summary>
         /// The <see cref="MobileServiceClient"/> associated with this 
         /// <see cref="MobileServiceAuthentication"/> instance.
         /// </summary>
@@ -113,6 +123,11 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// Provider specific extra parameters that are sent as query string parameters to login endpoint.
         /// </summary>
         internal IDictionary<string, string> Parameters { get; private set; }
+
+        /// <summary>
+        /// Custom headers sent with the request as required by user.
+        /// </summary>
+        internal IDictionary<string, string> CustomHeaders { get; private set; }
 
         /// <summary>
         /// The start uri to use for authentication.

--- a/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceTokenAuthentication.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceTokenAuthentication.cs
@@ -64,9 +64,9 @@ namespace Microsoft.WindowsAzure.MobileServices
             string pathAndQuery = MobileServiceUrlBuilder.CombinePathAndQuery(path, queryString);
             if (client.AlternateLoginHost != null)
             {
-                return client.AlternateAuthHttpClient.RequestWithoutHandlersAsync(HttpMethod.Post, pathAndQuery, client.CurrentUser, token.ToString());
+                return client.AlternateAuthHttpClient.RequestWithoutHandlersAsync(HttpMethod.Post, pathAndQuery, client.CurrentUser, token.ToString(), MobileServiceFeatures.None, CustomHeaders);
             }
-            return client.HttpClient.RequestWithoutHandlersAsync(HttpMethod.Post, pathAndQuery, client.CurrentUser, token.ToString());
+            return client.HttpClient.RequestWithoutHandlersAsync(HttpMethod.Post, pathAndQuery, client.CurrentUser, token.ToString(), MobileServiceFeatures.None, CustomHeaders);
         }
     }
 }

--- a/src/Microsoft.WindowsAzure.MobileServices/Extensions/MobileServiceClientExtensions.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Extensions/MobileServiceClientExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.WindowsAzure.MobileServices
             MobileServiceTokenAuthentication tokenAuth = new MobileServiceTokenAuthentication(thisClient,
                 MobileServiceAuthenticationProvider.MicrosoftAccount.ToString(),
                 token, parameters: null);
-
+            
             return tokenAuth.LoginAsync();
         }
     }

--- a/src/Microsoft.WindowsAzure.MobileServices/Http/MobileServiceHttpClient.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Http/MobileServiceHttpClient.cs
@@ -162,13 +162,20 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// </param>
         /// <param name="features">
         /// Optional MobileServiceFeatures used for telemetry purpose.
-        /// </param>>
+        /// </param>
+        /// <param name="customHeaders">
+        /// Optional custom headers to send with request, if needed
+        /// </param>
         /// <returns>
         /// The content of the response as a string.
         /// </returns>
-        public async Task<string> RequestWithoutHandlersAsync(HttpMethod method, string uriPathAndQuery, MobileServiceUser user, string content = null, MobileServiceFeatures features = MobileServiceFeatures.None)
+        public async Task<string> RequestWithoutHandlersAsync(HttpMethod method, string uriPathAndQuery, MobileServiceUser user, string content = null, MobileServiceFeatures features = MobileServiceFeatures.None, IDictionary<string, string> customHeaders = null)
         {
             IDictionary<string, string> requestHeaders = FeaturesHelper.AddFeaturesHeader(requestHeaders: null, features: features);
+
+            if (customHeaders != null)
+                requestHeaders.Add(customHeaders);
+
             MobileServiceHttpResponse response = await this.RequestAsync(false, method, uriPathAndQuery, user, content, false, requestHeaders);
             return response.Content;
         }

--- a/src/Microsoft.WindowsAzure.MobileServices/IMobileServiceClient.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/IMobileServiceClient.cs
@@ -132,6 +132,41 @@ namespace Microsoft.WindowsAzure.MobileServices
         Task<MobileServiceUser> LoginAsync(MobileServiceAuthenticationProvider provider, JObject token);
 
         /// <summary>
+        /// Logs a user into a Windows Azure Mobile Service with the provider and a token object.
+        /// </summary>
+        /// <param name="provider">
+        /// Authentication provider to use.
+        /// </param>
+        /// <param name="token">
+        /// Provider specific object with existing OAuth token to log in with.
+        /// </param>
+        /// <param name="customHeaders">
+        /// User-specified custom headers to send with request
+        /// </param>
+        /// <remarks>
+        /// The token object needs to be formatted depending on the specific provider. These are some
+        /// examples of formats based on the providers:
+        /// <list type="bullet">
+        ///   <item>
+        ///     <term>MicrosoftAccount</term>
+        ///     <description><code>{"authenticationToken":"&lt;the_authentication_token&gt;"}</code></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>Facebook</term>
+        ///     <description><code>{"access_token":"&lt;the_access_token&gt;"}</code></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>Google</term>
+        ///     <description><code>{"access_token":"&lt;the_access_token&gt;"}</code></description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        /// <returns>
+        /// Task that will complete when the user has finished authentication.
+        /// </returns>
+        Task<MobileServiceUser> LoginAsync(MobileServiceAuthenticationProvider provider, JObject token, IDictionary<string, string> customHeaders);
+
+        /// <summary>
         /// Logs a user into a Microsoft Azure Mobile Service with the provider and a token object.
         /// </summary>
         /// <param name="provider">
@@ -162,6 +197,41 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// Task that will complete when the user has finished authentication.
         /// </returns>
         Task<MobileServiceUser> LoginAsync(string provider, JObject token);
+
+        /// <summary>
+        /// Logs a user into a Microsoft Azure Mobile Service with the provider and a token object.
+        /// </summary>
+        /// <param name="provider">
+        /// Authentication provider to use.
+        /// </param>
+        /// <param name="token">
+        /// Provider specific object with existing OAuth token to log in with.
+        /// </param>
+        /// <param name="customHeaders">
+        /// User-specified custom headers to send with request
+        /// </param>
+        /// <remarks>
+        /// The token object needs to be formatted depending on the specific provider. These are some
+        /// examples of formats based on the providers:
+        /// <list type="bullet">
+        ///   <item>
+        ///     <term>MicrosoftAccount</term>
+        ///     <description><code>{"authenticationToken":"&lt;the_authentication_token&gt;"}</code></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>Facebook</term>
+        ///     <description><code>{"access_token":"&lt;the_access_token&gt;"}</code></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>Google</term>
+        ///     <description><code>{"access_token":"&lt;the_access_token&gt;"}</code></description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        /// <returns>
+        /// Task that will complete when the user has finished authentication.
+        /// </returns>
+        Task<MobileServiceUser> LoginAsync(string provider, JObject token, IDictionary<string, string> customHeaders);
 
         /// <summary>
         /// Log a user out.

--- a/src/Microsoft.WindowsAzure.MobileServices/MobileServiceClient.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/MobileServiceClient.cs
@@ -359,6 +359,50 @@ namespace Microsoft.WindowsAzure.MobileServices
         }
 
         /// <summary>
+        /// Logs a user into a Windows Azure Mobile Service with the provider, an optional token object and optional custom headers.
+        /// </summary>
+        /// <param name="provider">
+        /// Authentication provider to use.
+        /// </param>
+        /// <param name="token">
+        /// Provider specific object with existing OAuth token to log in with.
+        /// </param>
+        /// <param name="customHeaders">
+        /// User-specified custom headers to send with request
+        /// </param>
+        /// <remarks>
+        /// The token object needs to be formatted depending on the specific provider. These are some
+        /// examples of formats based on the providers:
+        /// <list type="bullet">
+        ///   <item>
+        ///     <term>MicrosoftAccount</term>
+        ///     <description><code>{"authenticationToken":"&lt;the_authentication_token&gt;"}</code></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>Facebook</term>
+        ///     <description><code>{"access_token":"&lt;the_access_token&gt;"}</code></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>Google</term>
+        ///     <description><code>{"access_token":"&lt;the_access_token&gt;"}</code></description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        /// <returns>
+        /// Task that will complete when the user has finished authentication.
+        /// </returns>
+        [SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Login", Justification = "Login is more appropriate than LogOn for our usage.")]
+        public Task<MobileServiceUser> LoginAsync(MobileServiceAuthenticationProvider provider, JObject token, IDictionary<string, string> customHeaders)
+        {
+            if (!Enum.IsDefined(typeof(MobileServiceAuthenticationProvider), provider))
+            {
+                throw new ArgumentOutOfRangeException("provider");
+            }
+
+            return this.LoginAsync(provider.ToString(), token, customHeaders);
+        }
+
+        /// <summary>
         /// Logs a user into a Microsoft Azure Mobile Service with the provider and optional token object.
         /// </summary>
         /// <param name="provider">
@@ -396,6 +440,51 @@ namespace Microsoft.WindowsAzure.MobileServices
             }
 
             MobileServiceTokenAuthentication auth = new MobileServiceTokenAuthentication(this, provider, token, parameters: null);
+            return auth.LoginAsync();
+        }
+
+        /// <summary>
+        /// Logs a user into a Microsoft Azure Mobile Service with the provider, an optional token object and optional custom headers.
+        /// </summary>
+        /// <param name="provider">
+        /// Authentication provider to use.
+        /// </param>
+        /// <param name="token">
+        /// Provider specific object with existing OAuth token to log in with.
+        /// </param>
+        /// <param name="customHeaders">
+        /// User-specified custom headers to send with request
+        /// </param>
+        /// <remarks>
+        /// The token object needs to be formatted depending on the specific provider. These are some
+        /// examples of formats based on the providers:
+        /// <list type="bullet">
+        ///   <item>
+        ///     <term>MicrosoftAccount</term>
+        ///     <description><code>{"authenticationToken":"&lt;the_authentication_token&gt;"}</code></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>Facebook</term>
+        ///     <description><code>{"access_token":"&lt;the_access_token&gt;"}</code></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>Google</term>
+        ///     <description><code>{"access_token":"&lt;the_access_token&gt;"}</code></description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        /// <returns>
+        /// Task that will complete when the user has finished authentication.
+        /// </returns>
+        public Task<MobileServiceUser> LoginAsync(string provider, JObject token, IDictionary<string, string> customHeaders)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException("token");
+            }
+
+            MobileServiceTokenAuthentication auth = new MobileServiceTokenAuthentication(this, provider, token, parameters: null);
+            auth.SetCustomHeaders(customHeaders);
             return auth.LoginAsync();
         }
 


### PR DESCRIPTION
This is required when piping the LoginAsync call through Azure API Management services. API Management requires a Subscription key to be sent with **every** request. This is just one example of a use of custom headers with this SDK.
