### PR TITLE
(#56) Add force purge to generic sync table

### DIFF
--- a/e2etest/Android.E2ETest/Android.E2ETest.csproj
+++ b/e2etest/Android.E2ETest/Android.E2ETest.csproj
@@ -17,7 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/e2etest/Android.E2ETest/Android.E2ETest.csproj
+++ b/e2etest/Android.E2ETest/Android.E2ETest.csproj
@@ -17,7 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/IMobileServiceSyncTable.Generic.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/IMobileServiceSyncTable.Generic.cs
@@ -96,7 +96,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
         /// A string that uniquely identifies this query and is used to keep track of its sync state. Supplying this parameter enables incremental sync whenever the same key is used again.
         /// </param>
         /// <param name="query">
-        /// An OData query that determines which items to 
+        /// An OData query that determines which items to
         /// pull from the remote table.
         /// </param>
         /// <param name="pushOtherTables">
@@ -123,6 +123,19 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
         /// </param>
         /// <returns>A task that completes when purge operation has finished.</returns>
         Task PurgeAsync<U>(string queryId, IMobileServiceTableQuery<U> query, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Deletes all the items in local table that match the query.
+        /// </summary>
+        /// <param name="queryId">
+        /// A string that uniquely identifies this query and is used to keep track of its sync state. Supplying this parameter resets the incremental sync state for the query.
+        /// </param>
+        /// <param name="query">An OData query that determines which items to delete.</param>
+        /// <param name="force">Force the purge by discarding the pending operations.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe
+        /// </param>
+        /// <returns>A task that completes when purge operation has finished.</returns>
+        Task PurgeAsync<U>(string queryId, IMobileServiceTableQuery<U> query, bool force, CancellationToken cancellationToken);
 
         /// <summary>
         /// Lookup an instance from a table by its id.

--- a/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/MobileServiceSyncTable.Generic.cs
+++ b/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/MobileServiceSyncTable.Generic.cs
@@ -56,13 +56,18 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
 
         public Task PurgeAsync<U>(string queryId, IMobileServiceTableQuery<U> query, CancellationToken cancellationToken)
         {
+            return this.PurgeAsync<U>(queryId, query, false, cancellationToken);
+        }
+
+        public Task PurgeAsync<U>(string queryId, IMobileServiceTableQuery<U> query, bool force, CancellationToken cancellationToken)
+        {
             if (query == null)
             {
                 throw new ArgumentNullException("query");
             }
             string queryString = this.queryProvider.ToODataString(query);
 
-            return this.PurgeAsync(queryId, queryString, false, cancellationToken);
+            return this.PurgeAsync(queryId, queryString, force, cancellationToken);
         }
 
         public async Task RefreshAsync(T instance)


### PR DESCRIPTION
Updated the IMobileServiceSyncTable.Generic definition to include a purge with force parameter.  Included a concrete example as well.

Closes #56 