### PR TITLE
Updating query id length for ValidateQueryId_Throws_OnInvalidId test

### DIFF
--- a/unittest/Microsoft.WindowsAzure.MobileServices.Test.Unit/Table/Sync/MobileServiceSyncTableTests.cs
+++ b/unittest/Microsoft.WindowsAzure.MobileServices.Test.Unit/Table/Sync/MobileServiceSyncTableTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test.Unit.Table.Sync
             foreach (var queryId in testCases)
             {
                 var ex = AssertEx.Throws<ArgumentException>(() => MobileServiceSyncTable.ValidateQueryId(queryId));
-                Assert.AreEqual(ex.Message, "The query id must not contain pipe character and should be less than 50 characters in length.\r\nParameter name: queryId");
+                Assert.AreEqual(ex.Message, "The query id must not contain pipe character and should be less than 255 characters in length.\r\nParameter name: queryId");
             }
         }
 


### PR DESCRIPTION
Need to fix test failure to sign MSIs for SDK build job