### PR TITLE
Ignore JsonReaderException, because 'rawResult' might not be JSON

### DIFF
--- a/src/Microsoft.Azure.Mobile.Client/Table/Sync/Queue/Operations/MobileServiceTableOperationError.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Table/Sync/Queue/Operations/MobileServiceTableOperationError.cs
@@ -190,7 +190,15 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
             string itemStr = obj.Value<string>("item");
             JObject item = itemStr == null ? null : JObject.Parse(itemStr);
             string rawResult = obj.Value<string>("rawResult");
-            var result = rawResult.ParseToJToken(settings) as JObject;
+            JObject result = null;
+            try
+            {
+                result = rawResult.ParseToJToken(settings) as JObject;
+            }
+            catch (JsonReaderException)
+            {
+                // Ignore JsonReaderException, because 'rawResult' might not be JSON.
+            }
 
             return new MobileServiceTableOperationError(id,
                                                         operationVersion,


### PR DESCRIPTION
During tests, I noticed that `rawResult` might not be JSON. For example:
`rawResult = "Cannot POST /tables/OfflineReady"`
then, next exception will be thrown:
```C#
Microsoft.WindowsAzure.MobileServices.Sync.MobileServicePushFailedException: Push operation has failed. See the PushResult for details. 
---> Microsoft.WindowsAzure.MobileServices.Sync.MobileServiceLocalStoreException: Failed to read errors from the local store. 
---> Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: C. Path '', line 0, position 0.
```
In that case, user get parse exception instead of an original error.