### PR TITLE
Fix NSData convertation for iOS 13

### DIFF
--- a/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
@@ -9,6 +9,7 @@ namespace Microsoft.WindowsAzure.MobileServices
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using System.Text;
     using Newtonsoft.Json.Linq;
 
 #if __UNIFIED__
@@ -107,8 +108,15 @@ namespace Microsoft.WindowsAzure.MobileServices
             {
                 throw new ArgumentNullException("deviceToken");
             }
-
-            return deviceToken.Description.Trim('<', '>').Replace(" ", string.Empty).ToUpperInvariant();
+            byte[] byteArray = deviceToken.ToArray();
+            if (byteArray.Length == 0)
+            {
+                throw new ArgumentException("deviceToken.ToArray() returned empty array.");
+            }
+            StringBuilder hex = new StringBuilder(byteArray.Length * 2);
+            foreach (byte b in byteArray)
+                hex.AppendFormat("{0:x2}", b);
+            return hex.ToString();
         }
     }
 }

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
@@ -115,7 +115,9 @@ namespace Microsoft.WindowsAzure.MobileServices
             }
             StringBuilder hex = new StringBuilder(byteArray.Length * 2);
             foreach (byte b in byteArray)
+            {
                 hex.AppendFormat("{0:x2}", b);
+            }                
             return hex.ToString();
         }
     }


### PR DESCRIPTION
This PR is supposed to fix iOS 13 NSData-to-hex conversion.

[#283](https://github.com/Azure/azure-mobile-apps-net-server/issues/283/)
#519 

[AB#71688](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/71688)
[AB#70228](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/70228)