### PR TITLE
Fix disposing files

### DIFF
--- a/src/Microsoft.Azure.Mobile.Client/Platforms/android/CurrentPlatform.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/android/CurrentPlatform.cs
@@ -82,7 +82,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         {
             if (!File.Exists(path))
             {
-                File.Create(path).Close();
+                File.Create(path).Dispose();
             }
         }
     }

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/ios/CurrentPlatform.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/ios/CurrentPlatform.cs
@@ -82,7 +82,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         {
             if (!File.Exists(path))
             {
-                File.Create(path).Close();
+                File.Create(path).Dispose();
             }
         }
     }

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/net45/CurrentPlatform.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/net45/CurrentPlatform.cs
@@ -62,7 +62,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         {
             if (!File.Exists(path))
             {
-                File.Create(path).Close();
+                File.Create(path).Dispose();
             }
         }
     }

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/netstandard14/CurrentPlatform.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/netstandard14/CurrentPlatform.cs
@@ -63,7 +63,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         {
             if (!File.Exists(path))
             {
-                File.Create(path).Close();
+                File.Create(path).Dispose();
             }
         }
     }


### PR DESCRIPTION
Fixes #512, #513

`Stream.Close` is unavailable in .NET standard 1.4.

See https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.close
> You do not have to specifically call the `Close` method. Instead, ensure that every `Stream` object is properly disposed.