### PR TITLE
Fix NSData convertation for iOS 13

### DIFF
--- a/e2etest/iOS.E2ETest/Functional/PushFunctional.Test.cs
+++ b/e2etest/iOS.E2ETest/Functional/PushFunctional.Test.cs
@@ -33,7 +33,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             NSData channelUri = NSDataFromDescription(this.pushTestUtility.GetPushHandle());
             Dictionary<string, string> channelUriParam = new Dictionary<string, string>()
             {
-                {"channelUri", TrimDeviceToken(channelUri.Description)}
+                {"channelUri", TrimDeviceToken(channelUri)}
             };
             await this.GetClient().InvokeApiAsync("deleteRegistrationsForChannel", HttpMethod.Delete, channelUriParam);
         }
@@ -46,7 +46,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             await push.RegisterAsync(channelUri);
             Dictionary<string, string> parameters = new Dictionary<string, string>()
             {
-                {"channelUri", TrimDeviceToken(channelUri.Description)}
+                {"channelUri", TrimDeviceToken(channelUri)}
             };
             await VerifyRegistration(parameters, push);
         }
@@ -59,7 +59,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             NSData channelUri = NSDataFromDescription(this.pushTestUtility.GetPushHandle());
             Dictionary<string, string> parameters = new Dictionary<string, string>()
             {
-                {"channelUri", TrimDeviceToken(channelUri.Description)}
+                {"channelUri", TrimDeviceToken(channelUri)}
             };
             var push = this.GetClient().GetPush();
             await push.RegisterAsync(channelUri);
@@ -87,14 +87,14 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
                 await push.RegisterAsync(channelUri);
                 Dictionary<string, string> parameters = new Dictionary<string, string>()
                 {
-                    {"channelUri", TrimDeviceToken(channelUri.Description)},
+                    {"channelUri", TrimDeviceToken(channelUri)},
                 };
                 await this.GetClient().InvokeApiAsync("verifyRegisterInstallationResult", HttpMethod.Get, parameters);
 
                 await push.RegisterAsync(channelUri, templates);
                 parameters = new Dictionary<string, string>()
                 {
-                    {"channelUri", TrimDeviceToken(channelUri.Description)},
+                    {"channelUri", TrimDeviceToken(channelUri)},
                     {"templates", JsonConvert.SerializeObject(expectedTemplates)}
                 };
                 await this.GetClient().InvokeApiAsync("verifyRegisterInstallationResult", HttpMethod.Get, parameters);
@@ -102,7 +102,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
                 await push.RegisterAsync(channelUri);
                 parameters = new Dictionary<string, string>()
                 {
-                    {"channelUri", TrimDeviceToken(channelUri.Description)},
+                    {"channelUri", TrimDeviceToken(channelUri)},
                 };
                 await this.GetClient().InvokeApiAsync("verifyRegisterInstallationResult", HttpMethod.Get, parameters);
             }
@@ -124,7 +124,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             {
                 Dictionary<string, string> parameters = new Dictionary<string, string>()
                 {
-                     {"channelUri", TrimDeviceToken(channelUri.Description)},
+                     {"channelUri", TrimDeviceToken(channelUri)},
                      {"templates", JsonConvert.SerializeObject(expectedTemplates)}
                 };
                 await push.RegisterAsync(channelUri, templates);
@@ -172,13 +172,13 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             return templates;
         }
 
-        internal static string TrimDeviceToken(string deviceToken)
+        internal static string TrimDeviceToken(NSData deviceToken)
         {
             if (deviceToken == null)
             {
                 throw new ArgumentNullException("deviceToken");
             }
-            byte[] byteArray = Encoding.ASCII.GetBytes(deviceToken);
+            byte[] byteArray = deviceToken.ToArray();
             if (byteArray.Length == 0)
             {
                 throw new ArgumentException("deviceToken bytes is empty array.");
@@ -193,12 +193,11 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
 
         internal static NSData NSDataFromDescription(string hexString)
         {
-            hexString = hexString.Trim('<', '>').Replace(" ", string.Empty);
             NSMutableData data = new NSMutableData();
             byte[] hexAsBytes = new byte[hexString.Length / 2];
-            for (int index = 0; index < hexAsBytes.Length; index += 2)
+            for (int index = 0; index < hexAsBytes.Length; index++)
             {
-                hexAsBytes[index / 2] = Convert.ToByte(hexString.Substring(index, 2), 16);
+                hexAsBytes[index] = Convert.ToByte(hexString.Substring(index * 2, 2), 16);
             }
 
             data.AppendBytes(hexAsBytes);

--- a/e2etest/iOS.E2ETest/Functional/PushFunctional.Test.cs
+++ b/e2etest/iOS.E2ETest/Functional/PushFunctional.Test.cs
@@ -193,6 +193,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
 
         internal static NSData NSDataFromDescription(string hexString)
         {
+            hexString = hexString.Trim('<', '>').Replace(" ", string.Empty);
             NSMutableData data = new NSMutableData();
             byte[] hexAsBytes = new byte[hexString.Length / 2];
             for (int index = 0; index < hexAsBytes.Length; index += 2)

--- a/e2etest/iOS.E2ETest/Functional/PushFunctional.Test.cs
+++ b/e2etest/iOS.E2ETest/Functional/PushFunctional.Test.cs
@@ -8,12 +8,12 @@ using Microsoft.WindowsAzure.MobileServices.TestFramework;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using System;
 using Foundation;
 using System.Globalization;
 using Newtonsoft.Json;
-using System.Text;
 
 namespace Microsoft.WindowsAzure.MobileServices.Test
 {

--- a/e2etest/iOS.E2ETest/Functional/PushFunctional.Test.cs
+++ b/e2etest/iOS.E2ETest/Functional/PushFunctional.Test.cs
@@ -13,6 +13,7 @@ using System;
 using Foundation;
 using System.Globalization;
 using Newtonsoft.Json;
+using System.Text;
 
 namespace Microsoft.WindowsAzure.MobileServices.Test
 {
@@ -177,19 +178,26 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             {
                 throw new ArgumentNullException("deviceToken");
             }
-
-            return deviceToken.Trim('<', '>').Replace(" ", string.Empty).ToUpperInvariant();
+            byte[] byteArray = Encoding.ASCII.GetBytes(deviceToken);
+            if (byteArray.Length == 0)
+            {
+                throw new ArgumentException("deviceToken bytes is empty array.");
+            }
+            StringBuilder hex = new StringBuilder(byteArray.Length * 2);
+            foreach (byte b in byteArray)
+            {
+                hex.AppendFormat("{0:x2}", b);
+            }
+            return hex.ToString();
         }
 
         internal static NSData NSDataFromDescription(string hexString)
         {
-            hexString = hexString.Trim('<', '>').Replace(" ", string.Empty);
             NSMutableData data = new NSMutableData();
             byte[] hexAsBytes = new byte[hexString.Length / 2];
-            for (int index = 0; index < hexAsBytes.Length; index++)
+            for (int index = 0; index < hexAsBytes.Length; index += 2)
             {
-                string byteValue = hexString.Substring(index * 2, 2);
-                hexAsBytes[index] = byte.Parse(byteValue, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                hexAsBytes[index / 2] = Convert.ToByte(hexString.Substring(index, 2), 16);
             }
 
             data.AppendBytes(hexAsBytes);

--- a/e2etest/iOS.E2ETest/TestPlatform/PushTestUtility.cs
+++ b/e2etest/iOS.E2ETest/TestPlatform/PushTestUtility.cs
@@ -16,7 +16,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
     class PushTestUtility : IPushTestUtility
     {
         private const string DefaultDeviceToken =
-            "<f6e7cd2 80fc5b5 d488f8394baf216506bc1bba 864d5b483d>";
+            "f6e7cd280fc5b5d488f8394baf216506bc1bba864d5b483d";
         const string BodyTemplate = "{\"aps\": {\"alert\":\"boo!\"}, \"extraprop\":\"($message)\"}";
         const string DefaultToastTemplateName = "templateForToastApns";
         readonly string[] DefaultTags = { "fooApns", "barApns" };        

--- a/e2etest/iOS.E2ETest/TestPlatform/PushTestUtility.cs
+++ b/e2etest/iOS.E2ETest/TestPlatform/PushTestUtility.cs
@@ -16,7 +16,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
     class PushTestUtility : IPushTestUtility
     {
         private const string DefaultDeviceToken =
-            "<f6e7cd2 80fc5b5 d488f8394baf216506bc1bba 864d5b483d>";
+            "f6e7cd2 80fc5b5 d488f8394baf216506bc1bba 864d5b483d";
         const string BodyTemplate = "{\"aps\": {\"alert\":\"boo!\"}, \"extraprop\":\"($message)\"}";
         const string DefaultToastTemplateName = "templateForToastApns";
         readonly string[] DefaultTags = { "fooApns", "barApns" };        

--- a/e2etest/iOS.E2ETest/TestPlatform/PushTestUtility.cs
+++ b/e2etest/iOS.E2ETest/TestPlatform/PushTestUtility.cs
@@ -16,7 +16,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
     class PushTestUtility : IPushTestUtility
     {
         private const string DefaultDeviceToken =
-            "f6e7cd2 80fc5b5 d488f8394baf216506bc1bba 864d5b483d";
+            "<f6e7cd2 80fc5b5 d488f8394baf216506bc1bba 864d5b483d>";
         const string BodyTemplate = "{\"aps\": {\"alert\":\"boo!\"}, \"extraprop\":\"($message)\"}";
         const string DefaultToastTemplateName = "templateForToastApns";
         readonly string[] DefaultTags = { "fooApns", "barApns" };        

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
@@ -9,6 +9,7 @@ namespace Microsoft.WindowsAzure.MobileServices
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using System.Text;
     using Newtonsoft.Json.Linq;
 
 #if __UNIFIED__
@@ -107,8 +108,15 @@ namespace Microsoft.WindowsAzure.MobileServices
             {
                 throw new ArgumentNullException("deviceToken");
             }
-
-            return deviceToken.Description.Trim('<', '>').Replace(" ", string.Empty).ToUpperInvariant();
+            byte[] byteArray = deviceToken.ToArray();
+            if (byteArray.Length == 0)
+            {
+                throw new ArgumentException("deviceToken.ToArray() returned empty array.");
+            }
+            StringBuilder hex = new StringBuilder(byteArray.Length * 2);
+            foreach (byte b in byteArray)
+                hex.AppendFormat("{0:x2}", b);
+            return hex.ToString();
         }
     }
 }

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
@@ -115,7 +115,9 @@ namespace Microsoft.WindowsAzure.MobileServices
             }
             StringBuilder hex = new StringBuilder(byteArray.Length * 2);
             foreach (byte b in byteArray)
+            {
                 hex.AppendFormat("{0:x2}", b);
+            }                
             return hex.ToString();
         }
     }

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Push/Push.cs
@@ -111,7 +111,7 @@ namespace Microsoft.WindowsAzure.MobileServices
             byte[] byteArray = deviceToken.ToArray();
             if (byteArray.Length == 0)
             {
-                throw new ArgumentException("deviceToken.ToArray() returned empty array.");
+                throw new ArgumentException("deviceToken cannot be empty.");
             }
             StringBuilder hex = new StringBuilder(byteArray.Length * 2);
             foreach (byte b in byteArray)


### PR DESCRIPTION
This PR is supposed to fix iOS 13 NSData-to-hex conversion.

[#283](https://github.com/Azure/azure-mobile-apps-net-server/issues/283/)
#519 

[AB#71688](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/71688)
[AB#70228](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/70228)