### PR TITLE
Check compression header of response

### DIFF
--- a/src/Microsoft.Azure.Mobile.Client/Http/MobileServiceHttpClient.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Http/MobileServiceHttpClient.cs
@@ -583,21 +583,15 @@ namespace Microsoft.WindowsAzure.MobileServices
                 {
                     return false;
                 }
-                else
-                {
-                    string allVaryValues = VaryList.Aggregate((allValues, next) => allValues = allValues + ";" + next);
-                    return !string.IsNullOrEmpty(allVaryValues) && allVaryValues.Contains("Accept-Encoding");
-                }
+                string allVaryValues = VaryList.Aggregate((allValues, next) => allValues = allValues + ";" + next);
+                return !string.IsNullOrEmpty(allVaryValues) && allVaryValues.Contains("Accept-Encoding");
             }
-            else
-            {
-                string allEncodingValues = EncodingList.Aggregate((allValues, next) => allValues = allValues + ";" + next);
-                return !string.IsNullOrEmpty(allEncodingValues) &&
-                     (allEncodingValues.Contains("gzip") ||
-                     allEncodingValues.Contains("deflate") ||
-                     allEncodingValues.Contains("br") ||
-                     allEncodingValues.Contains("compress"));
-            }
+            string allEncodingValues = EncodingList.Aggregate((allValues, next) => allValues = allValues + ";" + next);
+            return !string.IsNullOrEmpty(allEncodingValues) &&
+                    (allEncodingValues.Contains("gzip") ||
+                    allEncodingValues.Contains("deflate") ||
+                    allEncodingValues.Contains("br") ||
+                    allEncodingValues.Contains("compress"));
         }
 
         /// <summary>


### PR DESCRIPTION
This PR aims to fix response compression detection.
Tested with node backend with and without enforced compression, against xamarin.forms client (main focus on MonoAndroid70 and MonoAndroid80).

[AB#69379](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/69379)
#514 