### PR TITLE
Let CI (or GitHub) control the versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,6 @@ stages:
             - pwsh: |
                 $tagVersion = $env:BUILD_SOURCEBRANCHNAME
                 Write-Host "Tag version: $tagVersion"
-                Write-Host "##vso[task.setvariable variable=BASE_VERSION]$tagVersion"
                 Write-Host "##vso[task.setvariable variable=NUGET_VERSION]$tagVersion"
               displayName: Override version for tags
               condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,10 @@ pr:
 
 variables:
   AREA_PATH: 'DevDiv\Xamarin SDK'
+  BASE_VERSION: 4.2.0
+  PREVIEW_LABEL: 'ci'
+  BUILD_NUMBER: $[counter(format('{0}_{1}_{2}', variables['BASE_VERSION'], variables['PREVIEW_LABEL'], variables['Build.SourceBranch']), 1)]
+  NUGET_VERSION: $[format('{0}-{1}.{2}', variables['BASE_VERSION'], variables['PREVIEW_LABEL'], variables['BUILD_NUMBER'])]
 
 resources:
   repositories:
@@ -32,6 +36,26 @@ stages:
           areaPath: $(AREA_PATH)
           validPackagePrefixes:
             - Microsoft.Azure.Mobile.Client
+          preBuildSteps:
+            - pwsh: |
+                $pr = "pr." + $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+                $nuget = $env:BASE_VERSION + "-" + $pr + "." + $env:BUILD_NUMBER
+                Write-Host "Preview label: $pr"
+                Write-Host "NuGet version: $nuget"
+                Write-Host "##vso[task.setvariable variable=PREVIEW_LABEL]$pr"
+                Write-Host "##vso[task.setvariable variable=NUGET_VERSION]$nuget"
+              displayName: Use a special preview label for PRs
+              condition: eq(variables['Build.Reason'], 'PullRequest')
+            - pwsh: |
+                $tagVersion = $env:BUILD_SOURCEBRANCHNAME
+                Write-Host "Tag version: $tagVersion"
+                Write-Host "##vso[task.setvariable variable=BASE_VERSION]$tagVersion"
+                Write-Host "##vso[task.setvariable variable=NUGET_VERSION]$tagVersion"
+              displayName: Override version for tags
+              condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+            - pwsh: |
+                Write-Host "##vso[build.updatebuildnumber]$env:NUGET_VERSION"
+              displayName: Update the build number with a more readable one
 
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - stage: signing

--- a/build.cake
+++ b/build.cake
@@ -4,6 +4,8 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
+var nugetVersion = Argument("nugetVersion", EnvironmentVariable("NUGET_VERSION") ?? "1.0.0");
+var baseVersion = Argument("baseVersion", EnvironmentVariable("BASE_VERSION") ?? "1.0.0");
 
 ///////////////////////////////////////////////////////////////////////////////
 // TASKS
@@ -17,7 +19,9 @@ Task("Build")
         .EnableBinaryLogger("./output/build.binlog")
         .WithRestore()
         .WithTarget("Build")
-        .WithProperty("PackageOutputPath", MakeAbsolute((DirectoryPath)"./output/").FullPath));
+        .WithProperty("PackageOutputPath", MakeAbsolute((DirectoryPath)"./output/").FullPath)
+        .WithProperty("PackageVersion", nugetVersion)
+        .WithProperty("Version", baseVersion));
 });
 
 Task("Test")

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,9 @@
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 var nugetVersion = Argument("nugetVersion", EnvironmentVariable("NUGET_VERSION") ?? "1.0.0");
-var baseVersion = Argument("baseVersion", EnvironmentVariable("BASE_VERSION") ?? "1.0.0");
+var baseVersion = nugetVersion.Contains("-")
+    ? nugetVersion.Substring(0, nugetVersion.IndexOf("-"))
+    : nugetVersion;
 
 ///////////////////////////////////////////////////////////////////////////////
 // TASKS
@@ -14,6 +16,9 @@ var baseVersion = Argument("baseVersion", EnvironmentVariable("BASE_VERSION") ??
 Task("Build")
     .Does(() =>
 {
+    Information("Building with NuGet version: {0}", nugetVersion);
+    Information("Building with assembly version: {0}", baseVersion);
+
     MSBuild("./Microsoft.Azure.Mobile.Client.sln", c => c
         .SetConfiguration(configuration)
         .EnableBinaryLogger("./output/build.binlog")

--- a/src/Microsoft.Azure.Mobile.Client.SQLiteStore/Microsoft.Azure.Mobile.Client.SQLiteStore.csproj
+++ b/src/Microsoft.Azure.Mobile.Client.SQLiteStore/Microsoft.Azure.Mobile.Client.SQLiteStore.csproj
@@ -2,7 +2,6 @@
   <Import Project="..\..\build\Microsoft.Azure.Mobile.Client.Build.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;monoandroid90;xamarin.ios10</TargetFrameworks>
-    <VersionPrefix>4.2.0</VersionPrefix>
     <PackageTitle>Azure Mobile SQLiteStore</PackageTitle>
     <Title>Azure Mobile SQLiteStore</Title>
     <Authors>Microsoft</Authors>

--- a/src/Microsoft.Azure.Mobile.Client/Microsoft.Azure.Mobile.Client.csproj
+++ b/src/Microsoft.Azure.Mobile.Client/Microsoft.Azure.Mobile.Client.csproj
@@ -6,7 +6,6 @@
     <LangVersion>8.0</LangVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
-    <VersionPrefix>4.2.0</VersionPrefix>
     <PackageTitle>Azure Mobile Client SDK</PackageTitle>
     <Title>Azure Mobile Client SDK</Title>
     <Authors>Microsoft</Authors>
@@ -27,7 +26,6 @@
     <Company>Microsoft</Company>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.2.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
- Local builds will always be 1.0.0, unless either the `NUGET_VERSION` env var is set or the `nugetVersion` CLI arg is passed.
- CI builds will override the package version using the `BASE_VERSION` variable
   - PRs will be `BASE_VERSION-pr.PRNUM.BUILD` or `1.0.0-pr.000.0`
   - main branch builds will be `BASE_VERSION-ci.BUILD` or `1.0.0-ci.0`
   - Tags will override, so whatever value is used will be the package version (both stable and preview)

If you tag a preview version `4.2.0-preview.1`, then this overrides everything:
 - NuGet version == `4.2.0-preview.1`
 - Assembly version == `4.2.0`

The `ci` "label" can be changed in the yaml to be anything that is alphanumeric. Things like `preview` or `alpha`, `beta`, `rc` can all be used.